### PR TITLE
feat(webhook-cli): add download command for fetching official webhook…

### DIFF
--- a/templates/stripe-invoice.payment_succeeded.json
+++ b/templates/stripe-invoice.payment_succeeded.json
@@ -1,0 +1,238 @@
+{
+  "url": "http://localhost:3000/webhooks/stripe",
+  "method": "POST",
+  "headers": [
+    { "key": "Stripe-Signature", "value": "t=1674244840,v1=example" }
+  ],
+  "body": {
+    "id": "evt_000000000000000000000000",
+    "object": "event",
+    "api_version": "2022-11-15",
+    "created": 1674244840,
+    "data": {
+      "object": {
+        "id": "in_1000000000000000000000000",
+        "object": "invoice",
+        "account_country": "US",
+        "account_name": "Account Name Here",
+        "account_tax_ids": null,
+        "amount_due": 0,
+        "amount_paid": 0,
+        "amount_remaining": 0,
+        "application": null,
+        "application_fee_amount": null,
+        "attempt_count": 0,
+        "attempted": true,
+        "auto_advance": false,
+        "automatic_tax": {
+          "enabled": false,
+          "status": null
+        },
+        "billing_reason": "subscription_cycle",
+        "charge": null,
+        "collection_method": "charge_automatically",
+        "created": 1674244834,
+        "currency": "usd",
+        "custom_fields": null,
+        "customer": "cus_00000000000000",
+        "customer_address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": "94142",
+          "state": null
+        },
+        "customer_email": "jdoe@example.com",
+        "customer_name": "John Doe",
+        "customer_phone": null,
+        "customer_shipping": null,
+        "customer_tax_exempt": "none",
+        "customer_tax_ids": [],
+        "default_payment_method": null,
+        "default_source": null,
+        "default_tax_rates": [],
+        "description": null,
+        "discount": {
+          "id": "di_000000000000000000000000",
+          "object": "discount",
+          "checkout_session": null,
+          "coupon": {
+            "id": "00000000",
+            "object": "coupon",
+            "amount_off": null,
+            "created": 1642708299,
+            "currency": null,
+            "duration": "forever",
+            "duration_in_months": null,
+            "livemode": true,
+            "max_redemptions": null,
+            "metadata": {},
+            "name": "Coupon Name Here",
+            "percent_off": 100,
+            "redeem_by": null,
+            "times_redeemed": 2,
+            "valid": true
+          },
+          "customer": "cus_00000000000000",
+          "end": null,
+          "invoice": null,
+          "invoice_item": null,
+          "promotion_code": "promo_000000000000000000000000",
+          "start": 1642708821,
+          "subscription": "sub_000000000000000000000000"
+        },
+        "discounts": ["di_000000000000000000000000"],
+        "due_date": null,
+        "ending_balance": 0,
+        "footer": null,
+        "from_invoice": null,
+        "hosted_invoice_url": "https://invoice.stripe.com/i/acct_00000000000000/live_xxx?s=ap",
+        "invoice_pdf": "https://pay.stripe.com/invoice/acct_00000000000000/live_xxx/pdf?s=ap",
+        "last_finalization_error": null,
+        "latest_revision": null,
+        "lines": {
+          "object": "list",
+          "data": [
+            {
+              "id": "il_000000000000000000000000",
+              "object": "line_item",
+              "amount": 50000,
+              "amount_excluding_tax": 50000,
+              "currency": "usd",
+              "description": "description goes here",
+              "discount_amounts": [
+                {
+                  "amount": 50000,
+                  "discount": "di_000000000000000000000000"
+                }
+              ],
+              "discountable": true,
+              "discounts": [],
+              "livemode": true,
+              "metadata": {},
+              "period": {
+                "end": 1676923221,
+                "start": 1674244821
+              },
+              "plan": {
+                "id": "price_000000000000000000000000",
+                "object": "plan",
+                "active": true,
+                "aggregate_usage": null,
+                "amount": 50000,
+                "amount_decimal": "50000",
+                "billing_scheme": "per_unit",
+                "created": 1642394608,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": true,
+                "metadata": {},
+                "nickname": null,
+                "product": "prod_00000000000000",
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "price": {
+                "id": "price_000000000000000000000000",
+                "object": "price",
+                "active": true,
+                "billing_scheme": "per_unit",
+                "created": 1642394608,
+                "currency": "usd",
+                "custom_unit_amount": null,
+                "livemode": true,
+                "lookup_key": null,
+                "metadata": {},
+                "nickname": null,
+                "product": "prod_00000000000000",
+                "recurring": {
+                  "aggregate_usage": null,
+                  "interval": "month",
+                  "interval_count": 1,
+                  "trial_period_days": null,
+                  "usage_type": "licensed"
+                },
+                "tax_behavior": "unspecified",
+                "tiers_mode": null,
+                "transform_quantity": null,
+                "type": "recurring",
+                "unit_amount": 50000,
+                "unit_amount_decimal": "50000"
+              },
+              "proration": false,
+              "proration_details": {
+                "credited_items": null
+              },
+              "quantity": 1,
+              "subscription": "sub_000000000000000000000000",
+              "subscription_item": "si_00000000000000",
+              "tax_amounts": [],
+              "tax_rates": [],
+              "type": "subscription",
+              "unit_amount_excluding_tax": "50000"
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/invoices/in_000000000000000000000000/lines"
+        },
+        "livemode": true,
+        "metadata": {},
+        "next_payment_attempt": null,
+        "number": "B29DAD55-0015",
+        "on_behalf_of": null,
+        "paid": true,
+        "paid_out_of_band": false,
+        "payment_intent": null,
+        "payment_settings": {
+          "default_mandate": null,
+          "payment_method_options": null,
+          "payment_method_types": null
+        },
+        "period_end": 1674244821,
+        "period_start": 1671566421,
+        "post_payment_credit_notes_amount": 0,
+        "pre_payment_credit_notes_amount": 0,
+        "quote": null,
+        "receipt_number": null,
+        "rendering_options": null,
+        "starting_balance": 0,
+        "statement_descriptor": null,
+        "status": "paid",
+        "status_transitions": {
+          "finalized_at": 1674248448,
+          "marked_uncollectible_at": null,
+          "paid_at": 1674248448,
+          "voided_at": null
+        },
+        "subscription": "sub_000000000000000000000000",
+        "subtotal": 50000,
+        "subtotal_excluding_tax": 50000,
+        "tax": null,
+        "test_clock": null,
+        "total": 0,
+        "total_discount_amounts": [
+          {
+            "amount": 50000,
+            "discount": "di_000000000000000000000000"
+          }
+        ],
+        "total_excluding_tax": 0,
+        "total_tax_amounts": [],
+        "transfer_data": null,
+        "webhooks_delivered_at": 1674244835
+      }
+    },
+    "livemode": true,
+    "pending_webhooks": 1,
+    "request": {
+      "id": "req_00000000000000",
+      "idempotency_key": null
+    },
+    "type": "invoice.payment_succeeded"
+  }
+}


### PR DESCRIPTION
This pull request adds a new feature to the CLI tool for managing webhook templates, specifically enabling users to download official webhook templates directly into their `.webhooks` directory. It introduces a new `download` command, fetches templates from a remote repository, validates them, and provides an initial Stripe invoice payment succeeded template.

**New CLI features and commands:**

* Added a `download` command to the CLI, allowing users to fetch official webhook templates from a remote repository. The command supports downloading a specific template by name, listing available templates, downloading all templates at once, and overwriting existing files with a `--force` flag.
* Updated the CLI description to reflect the new downloading capability.

**Template management and validation:**

* Integrated remote fetching using the `undici` HTTP client, and included schema validation for downloaded templates to ensure correctness before saving.

**New template added:**

* Added a Stripe `invoice.payment_succeeded` webhook template (`stripe-invoice.payment_succeeded.json`) as the first official downloadable template.