### PR TITLE
config: inject correct environment variable for npm release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed the npm authentication configuration by changing the environment variable from `NPM_TOKEN` to `NODE_AUTH_TOKEN` in the release workflow.

- When `setup-node@v4` is configured with `registry-url`, it expects authentication via the `NODE_AUTH_TOKEN` environment variable, not `NPM_TOKEN`
- The value still comes from the `NPM_TOKEN` secret, but is now correctly mapped to `NODE_AUTH_TOKEN` for the changesets publish action
- This aligns with the standard authentication pattern for npm publishing in GitHub Actions

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a correct fix for npm authentication in GitHub Actions. Using `NODE_AUTH_TOKEN` is the documented standard when `setup-node` is configured with `registry-url`, and the change properly maps the existing `NPM_TOKEN` secret to the correct environment variable name.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Changed environment variable from `NPM_TOKEN` to `NODE_AUTH_TOKEN` for npm authentication in the changesets action |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant Setup as setup-node@v4
    participant Changesets as changesets/action@v1
    participant NPM as npm Registry
    
    GH->>Setup: Configure Node.js with registry-url
    Setup->>Setup: Set registry to npmjs.org
    GH->>Changesets: Run release action
    Note over Changesets: Execute pnpm release:publish
    Changesets->>NPM: Authenticate using NODE_AUTH_TOKEN
    NPM-->>Changesets: Authentication successful
    Changesets->>NPM: Publish packages
    NPM-->>Changesets: Packages published
    Changesets->>GH: Create GitHub releases
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->