### PR TITLE
docs: adds homebrew and binary download instruction to docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,6 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push tags
+        run: git push --tags

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -13,7 +13,36 @@ The Better Webhook CLI is a local development tool for capturing, replaying, and
 
 ## Installation
 
-Install the CLI globally:
+### Standalone Binary (Recommended)
+
+Download a standalone binary - no Node.js required.
+
+**macOS (Homebrew)**
+
+```bash
+brew install endalk200/tap/better-webhook
+```
+
+**Manual Download**
+
+Download the latest binary for your platform from [GitHub Releases](https://github.com/endalk200/better-webhook/releases):
+
+| Platform      | Binary Name                   |
+| ------------- | ----------------------------- |
+| macOS (ARM)   | `better-webhook-darwin-arm64` |
+| macOS (Intel) | `better-webhook-darwin-x64`   |
+| Linux (x64)   | `better-webhook-linux-x64`    |
+| Linux (ARM)   | `better-webhook-linux-arm64`  |
+| Windows       | `better-webhook-windows-x64.exe` |
+
+```bash
+# Example: macOS ARM
+curl -L https://github.com/endalk200/better-webhook/releases/latest/download/better-webhook-darwin-arm64 -o better-webhook
+chmod +x better-webhook
+sudo mv better-webhook /usr/local/bin/
+```
+
+### NPM (Alternative)
 
 <Tabs groupId="package-manager" items={["npm", "pnpm", "yarn"]}>
   <Tab value="npm">
@@ -33,7 +62,13 @@ Install the CLI globally:
   </Tab>
 </Tabs>
 
-Verify the installation:
+Or use with npx (no installation required):
+
+```bash
+npx @better-webhook/cli --help
+```
+
+### Verify Installation
 
 ```bash
 better-webhook --version


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Homebrew and binary download installation instructions to the documentation and fixes the GitHub Actions release workflow to properly push tags.

**Key Changes:**
- Added `git push --tags` step in `.github/workflows/release.yml` to ensure tags created by changesets are pushed to GitHub, which triggers the binary-release workflow that builds and uploads CLI binaries
- Enhanced CLI documentation with three installation methods: Homebrew (recommended), manual binary downloads for all platforms (macOS ARM/Intel, Linux x64/ARM64, Windows), and NPM (alternative)
- Improved documentation structure by clearly organizing installation options with headings and examples
- Added npx usage instructions for users who don't want to install globally

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it's primarily documentation updates with a single workflow improvement
- The changes are straightforward: documentation enhancement and a necessary workflow fix. The `git push --tags` addition ensures the binary release workflow triggers correctly. The only consideration is verifying the Homebrew tap exists
- Verify the Homebrew tap at `endalk200/tap` is properly configured before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Added git push --tags step to ensure tags are pushed after changesets publishes packages, triggering the binary-release workflow |
| apps/docs/content/docs/cli/index.mdx | Added comprehensive installation instructions for Homebrew and manual binary downloads, reorganized documentation structure for better user experience |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Release as Release Workflow
    participant CS as Changesets
    participant NPM as NPM Registry
    participant Binary as Binary Release Workflow
    participant User as End User
    
    Dev->>GH: Push to main branch
    GH->>Release: Trigger release workflow
    Release->>Release: Build packages
    Release->>CS: Run changesets action
    CS->>NPM: Publish @better-webhook/cli
    CS->>GH: Create version tags
    Release->>GH: Push tags (git push --tags)
    GH->>Binary: Trigger binary-release workflow (on tag)
    Binary->>Binary: Build binaries for all platforms
    Binary->>GH: Upload binaries to GitHub Releases
    User->>GH: Download binary via curl or Homebrew
    User->>User: Install better-webhook CLI
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->