### PR TITLE
feat: cli config

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -31,8 +31,15 @@ jobs:
       - name: Setup Devbox
         uses: ./.github/actions/setup-devbox
 
+      - name: Configure npm registry auth
+        uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
       - name: Install dependencies
         run: devbox run -- just ci-install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || secrets.NODE_AUTH_TOKEN }}
 
       - name: Format check
         run: devbox run -- just format-check

--- a/apps/docs/app/(home)/components/footer.tsx
+++ b/apps/docs/app/(home)/components/footer.tsx
@@ -5,6 +5,7 @@ const footerLinks = {
   cli: [
     { name: "CLI Overview", href: "/docs/cli" },
     { name: "Command Reference", href: "/docs/cli/commands" },
+    { name: "Configuration", href: "/docs/cli/configuration" },
     { name: "Templates", href: "/docs/cli/templates" },
   ],
   sdk: [

--- a/apps/docs/content/docs/cli/commands.mdx
+++ b/apps/docs/content/docs/cli/commands.mdx
@@ -7,6 +7,23 @@ import { Callout } from "fumadocs-ui/components/callout";
 
 # Command Reference
 
+For configuration keys, path precedence, and environment variable details, see [Configuration](/docs/cli/configuration).
+
+## Global Options
+
+These options apply to all commands:
+
+| Option                  | Description |
+| ----------------------- | ----------- |
+| `--config <path>`       | Path to config TOML file |
+| `BETTER_WEBHOOK_CONFIG_PATH` | Environment variable alternative to `--config` |
+
+Initialize a default config file:
+
+```bash
+better-webhook init
+```
+
 ## capture
 
 Start a standalone server to capture incoming webhooks.

--- a/apps/docs/content/docs/cli/configuration.mdx
+++ b/apps/docs/content/docs/cli/configuration.mdx
@@ -1,0 +1,116 @@
+---
+title: Configuration
+description: Configure Better Webhook CLI with config files, environment variables, and command flags.
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+
+# Configuration
+
+The CLI supports three configuration layers:
+
+- Config file (`config.toml`)
+- Environment variables
+- Command flags
+
+Use this page to set up predictable defaults and reduce repetitive flags.
+
+## Quick Setup
+
+<Steps>
+  <Step>
+    ### Generate a default config file
+
+    ```bash
+    better-webhook init
+    ```
+
+    This creates `~/.better-webhook/config.toml` with documented defaults.
+  </Step>
+
+  <Step>
+    ### Review and adjust settings
+
+    Open the generated file and update directories or log level as needed.
+  </Step>
+
+  <Step>
+    ### Use overrides only when needed
+
+    Use environment variables or command flags for temporary changes.
+  </Step>
+</Steps>
+
+## Config File Location
+
+By default, the CLI resolves the config file path to:
+
+```text
+~/.better-webhook/config.toml
+```
+
+You can choose a different file path with `--config` or `BETTER_WEBHOOK_CONFIG_PATH`.
+
+## Config Path Precedence
+
+The CLI resolves **which config file to load** in this order:
+
+1. `--config <path>`
+2. `BETTER_WEBHOOK_CONFIG_PATH`
+3. `~/.better-webhook/config.toml`
+
+## Config Keys
+
+| Key             | Default                    | Env Override                         | Flag Override              | Description |
+| --------------- | -------------------------- | ------------------------------------ | -------------------------- | ----------- |
+| `captures_dir`  | `~/.better-webhook/captures`  | `BETTER_WEBHOOK_CAPTURES_DIR`     | `--captures-dir`           | Directory where captured webhook payloads are stored |
+| `templates_dir` | `~/.better-webhook/templates` | `BETTER_WEBHOOK_TEMPLATES_DIR`    | `--templates-dir`          | Directory where downloaded templates and cache files are stored |
+| `log_level`     | `info`                     | `BETTER_WEBHOOK_LOG_LEVEL`          | command-specific `--verbose` behavior | Default logging verbosity (`debug`, `info`, `warn`, `error`) |
+
+## Value Precedence
+
+For each setting value (`captures_dir`, `templates_dir`, `log_level`), precedence is:
+
+1. Command flags
+2. Environment variables
+3. Config file
+4. Built-in defaults
+
+This means one-off command flags always win over persistent defaults.
+
+## Environment Variables
+
+```bash
+# Config file path
+export BETTER_WEBHOOK_CONFIG_PATH="$HOME/.better-webhook/config.toml"
+
+# Value overrides
+export BETTER_WEBHOOK_CAPTURES_DIR="$HOME/tmp/bw-captures"
+export BETTER_WEBHOOK_TEMPLATES_DIR="$HOME/tmp/bw-templates"
+export BETTER_WEBHOOK_LOG_LEVEL="debug"
+```
+
+## Custom Config File Path
+
+```bash
+# Use an explicit config file for this command
+better-webhook --config ./configs/dev.toml captures list
+
+# Generate defaults into a custom path
+better-webhook --config ./configs/dev.toml init
+```
+
+<Callout type="info">
+  `init` does not overwrite existing files unless you pass `--force`.
+</Callout>
+
+## Example Config File
+
+```toml
+captures_dir = "~/.better-webhook/captures"
+templates_dir = "~/.better-webhook/templates"
+log_level = "info"
+```
+
+The generated config from `better-webhook init` includes additional inline comments and guidance.

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -137,4 +137,5 @@ Templates include proper headers and can generate valid signatures when you prov
 ## Next Steps
 
 - [Command Reference](/docs/cli/commands) — Full documentation for all CLI commands
+- [Configuration](/docs/cli/configuration) — Config file structure, env overrides, and precedence
 - [Templates](/docs/cli/templates) — Learn about available templates and how to use them

--- a/apps/docs/content/docs/cli/meta.json
+++ b/apps/docs/content/docs/cli/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "CLI",
-  "pages": ["index", "commands", "templates"]
+  "pages": ["index", "commands", "configuration", "templates"]
 }

--- a/apps/webhook-cli/cmd/better-webhook/main.go
+++ b/apps/webhook-cli/cmd/better-webhook/main.go
@@ -21,6 +21,7 @@ import (
 	apptemplates "github.com/endalk200/better-webhook/apps/webhook-cli/internal/app/templates"
 	capturecmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/capture"
 	capturescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/captures"
+	initcmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/init"
 	replaycmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/replay"
 	rootcmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/root"
 	templatescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/templates"
@@ -33,6 +34,9 @@ func main() {
 	rootCommand := rootcmd.NewCommand(rootcmd.Dependencies{
 		Version:      version.Version,
 		ConfigLoader: configtoml.NewLoader(),
+		InitDependencies: initcmd.Dependencies{
+			ConfigWriter: configtoml.NewWriter(),
+		},
 		CaptureDependencies: capturecmd.Dependencies{
 			ServiceFactory: newCaptureService,
 			ServerFactory:  httpcapture.NewServer,

--- a/apps/webhook-cli/internal/adapters/config/toml/writer.go
+++ b/apps/webhook-cli/internal/adapters/config/toml/writer.go
@@ -103,5 +103,5 @@ templates_dir = %q
 #   - BETTER_WEBHOOK_LOG_LEVEL
 #   - command flags like --verbose on supported commands
 log_level = %q
-`, runtime.EnvConfigPath, capturesDir, templatesDir, runtime.DefaultLogLevel)
+`, runtime.EnvConfigPath, capturesDir, templatesDir, defaults.LogLevel)
 }

--- a/apps/webhook-cli/internal/adapters/config/toml/writer.go
+++ b/apps/webhook-cli/internal/adapters/config/toml/writer.go
@@ -1,0 +1,107 @@
+package toml
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/runtime"
+)
+
+const defaultConfigFileMode = 0o600
+
+type Writer struct{}
+
+func NewWriter() Writer {
+	return Writer{}
+}
+
+func (Writer) WriteDefaultConfig(configPath string, overwrite bool) (runtime.ConfigWriteResult, error) {
+	trimmedPath := strings.TrimSpace(configPath)
+	if trimmedPath == "" {
+		return runtime.ConfigWriteResult{}, errors.New("config path cannot be empty")
+	}
+
+	existed, err := configFileExists(trimmedPath)
+	if err != nil {
+		return runtime.ConfigWriteResult{}, err
+	}
+	if existed && !overwrite {
+		return runtime.ConfigWriteResult{}, fmt.Errorf("%w: %s", runtime.ErrConfigFileAlreadyExists, trimmedPath)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(trimmedPath), 0o755); err != nil {
+		return runtime.ConfigWriteResult{}, fmt.Errorf("create config directory for %q: %w", trimmedPath, err)
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return runtime.ConfigWriteResult{}, fmt.Errorf("resolve home directory: %w", err)
+	}
+	content := renderDefaultConfigTemplate(runtime.DefaultConfig(homeDir))
+	if err := os.WriteFile(trimmedPath, []byte(content), defaultConfigFileMode); err != nil {
+		return runtime.ConfigWriteResult{}, fmt.Errorf("write config file %q: %w", trimmedPath, err)
+	}
+	return runtime.ConfigWriteResult{
+		Path:        trimmedPath,
+		Created:     !existed,
+		Overwritten: existed,
+	}, nil
+}
+
+func configFileExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return false, fmt.Errorf("config path %q points to a directory", path)
+		}
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("inspect config path %q: %w", path, err)
+}
+
+func renderDefaultConfigTemplate(defaults runtime.AppConfig) string {
+	capturesDir := filepath.ToSlash(defaults.CapturesDir)
+	templatesDir := filepath.ToSlash(defaults.TemplatesDir)
+	return fmt.Sprintf(`# Better Webhook CLI configuration
+#
+# This file is optional. The CLI works without it, but keeping defaults here
+# makes local development setup explicit and easier to share.
+#
+# Config file path precedence:
+#   1) --config <path>
+#   2) %s
+#   3) ~/.better-webhook/config.toml
+#
+# Value precedence for each setting:
+#   command flag > environment variable > this file > built-in default
+#
+# Path values support:
+#   - "~" home expansion
+#   - "$ENV_VAR" expansion
+#   - relative paths (resolved against the current working directory)
+
+# Directory where captured webhook payloads are persisted.
+# Override with:
+#   - --captures-dir
+#   - BETTER_WEBHOOK_CAPTURES_DIR
+captures_dir = %q
+
+# Directory for downloaded template files and cache data.
+# Override with:
+#   - --templates-dir
+#   - BETTER_WEBHOOK_TEMPLATES_DIR
+templates_dir = %q
+
+# Log level controls default verbosity for commands.
+# Supported values: "debug", "info", "warn", "error"
+# Override with:
+#   - BETTER_WEBHOOK_LOG_LEVEL
+#   - command flags like --verbose on supported commands
+log_level = %q
+`, runtime.EnvConfigPath, capturesDir, templatesDir, runtime.DefaultLogLevel)
+}

--- a/apps/webhook-cli/internal/adapters/config/toml/writer_test.go
+++ b/apps/webhook-cli/internal/adapters/config/toml/writer_test.go
@@ -1,0 +1,98 @@
+package toml
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/runtime"
+)
+
+func TestWriteDefaultConfigCreatesCommentedTemplate(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "nested", "config.toml")
+
+	result, err := NewWriter().WriteDefaultConfig(configPath, false)
+	if err != nil {
+		t.Fatalf("write default config: %v", err)
+	}
+	if !result.Created {
+		t.Fatalf("expected Created=true")
+	}
+	if result.Overwritten {
+		t.Fatalf("expected Overwritten=false")
+	}
+	if result.Path != configPath {
+		t.Fatalf("path mismatch: got %q want %q", result.Path, configPath)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	content := string(data)
+	assertContainsAll(t, content,
+		"# Better Webhook CLI configuration",
+		"BETTER_WEBHOOK_CONFIG_PATH",
+		"captures_dir",
+		"templates_dir",
+		"log_level",
+		"command flag > environment variable > this file > built-in default",
+	)
+}
+
+func TestWriteDefaultConfigRejectsOverwriteWithoutForce(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(configPath, []byte("log_level = \"warn\"\n"), 0o600); err != nil {
+		t.Fatalf("seed config file: %v", err)
+	}
+
+	_, err := NewWriter().WriteDefaultConfig(configPath, false)
+	if err == nil {
+		t.Fatalf("expected write without force to fail for existing config")
+	}
+	if !errors.Is(err, runtime.ErrConfigFileAlreadyExists) {
+		t.Fatalf("expected ErrConfigFileAlreadyExists, got %v", err)
+	}
+}
+
+func TestWriteDefaultConfigOverwritesWhenForced(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	original := "log_level = \"warn\"\n"
+	if err := os.WriteFile(configPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("seed config file: %v", err)
+	}
+
+	result, err := NewWriter().WriteDefaultConfig(configPath, true)
+	if err != nil {
+		t.Fatalf("write default config with force: %v", err)
+	}
+	if result.Created {
+		t.Fatalf("expected Created=false when overwriting")
+	}
+	if !result.Overwritten {
+		t.Fatalf("expected Overwritten=true when force is set")
+	}
+
+	updatedData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read updated config file: %v", err)
+	}
+	updated := string(updatedData)
+	if strings.Contains(updated, original) {
+		t.Fatalf("expected config file to be overwritten")
+	}
+	if !strings.Contains(updated, "captures_dir") {
+		t.Fatalf("expected overwritten config to contain default template")
+	}
+}
+
+func assertContainsAll(t *testing.T, content string, values ...string) {
+	t.Helper()
+	for _, value := range values {
+		if !strings.Contains(content, value) {
+			t.Fatalf("expected content to include %q, got %q", value, content)
+		}
+	}
+}

--- a/apps/webhook-cli/internal/adapters/config/toml/writer_test.go
+++ b/apps/webhook-cli/internal/adapters/config/toml/writer_test.go
@@ -31,6 +31,13 @@ func TestWriteDefaultConfigCreatesCommentedTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read config file: %v", err)
 	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(defaultConfigFileMode); got != want {
+		t.Fatalf("config mode mismatch: got %o want %o", got, want)
+	}
 	content := string(data)
 	assertContainsAll(t, content,
 		"# Better Webhook CLI configuration",
@@ -78,6 +85,13 @@ func TestWriteDefaultConfigOverwritesWhenForced(t *testing.T) {
 	updatedData, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read updated config file: %v", err)
+	}
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat overwritten config file: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(defaultConfigFileMode); got != want {
+		t.Fatalf("overwritten config mode mismatch: got %o want %o", got, want)
 	}
 	updated := string(updatedData)
 	if strings.Contains(updated, original) {

--- a/apps/webhook-cli/internal/cli/init/command.go
+++ b/apps/webhook-cli/internal/cli/init/command.go
@@ -1,0 +1,65 @@
+package init
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/runtime"
+	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/ui"
+)
+
+type ConfigWriter interface {
+	WriteDefaultConfig(configPath string, overwrite bool) (runtime.ConfigWriteResult, error)
+}
+
+type Dependencies struct {
+	ConfigWriter ConfigWriter
+}
+
+func NewCommand(deps Dependencies) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create a default CLI config file",
+		Long: "Create a default config TOML file with documented settings.\n\n" +
+			"Path precedence is: --config, BETTER_WEBHOOK_CONFIG_PATH, then ~/.better-webhook/config.toml.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if deps.ConfigWriter == nil {
+				return errors.New("config writer cannot be nil")
+			}
+			force, err := cmd.Flags().GetBool("force")
+			if err != nil {
+				return err
+			}
+			resolvedPath, err := runtime.ResolveConfigPath(cmd)
+			if err != nil {
+				return err
+			}
+			writeResult, err := deps.ConfigWriter.WriteDefaultConfig(resolvedPath.Path, force)
+			if err != nil {
+				if errors.Is(err, runtime.ErrConfigFileAlreadyExists) {
+					return fmt.Errorf("config file already exists at %q (use --force to overwrite)", resolvedPath.Path)
+				}
+				return err
+			}
+
+			if writeResult.Overwritten {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), ui.FormatSuccess("Overwrote config file."))
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), ui.FormatSuccess("Created default config file."))
+			}
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", ui.Bold.Render("Path"), ui.Info.Render(writeResult.Path))
+			_, _ = fmt.Fprintf(
+				cmd.OutOrStdout(),
+				"%s\n",
+				ui.Faint.Render("Tip: adjust values in the file or override with env vars/flags for one-off runs."),
+			)
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("force", false, "Overwrite existing config file")
+	return cmd
+}

--- a/apps/webhook-cli/internal/cli/init/command.go
+++ b/apps/webhook-cli/internal/cli/init/command.go
@@ -23,7 +23,7 @@ func NewCommand(deps Dependencies) *cobra.Command {
 		Use:   "init",
 		Short: "Create a default CLI config file",
 		Long: "Create a default config TOML file with documented settings.\n\n" +
-			"Path precedence is: --config, BETTER_WEBHOOK_CONFIG_PATH, then ~/.better-webhook/config.toml.",
+			"Path precedence is: --config, " + runtime.EnvConfigPath + ", then ~/.better-webhook/config.toml.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if deps.ConfigWriter == nil {

--- a/apps/webhook-cli/internal/cli/root/command.go
+++ b/apps/webhook-cli/internal/cli/root/command.go
@@ -5,6 +5,7 @@ import (
 
 	capturecmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/capture"
 	capturescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/captures"
+	initcmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/init"
 	templatescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/templates"
 	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/runtime"
 )
@@ -12,6 +13,7 @@ import (
 type Dependencies struct {
 	Version              string
 	ConfigLoader         runtime.Loader
+	InitDependencies     initcmd.Dependencies
 	CaptureDependencies  capturecmd.Dependencies
 	CapturesDependencies capturescmd.Dependencies
 	TemplateDependencies templatescmd.Dependencies
@@ -24,6 +26,9 @@ func NewCommand(deps Dependencies) *cobra.Command {
 		Long:    "A local CLI for capturing webhook requests with high-fidelity storage.",
 		Version: deps.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if shouldSkipConfigInitialization(cmd) {
+				return nil
+			}
 			return runtime.InitializeConfig(cmd, deps.ConfigLoader)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -33,9 +38,14 @@ func NewCommand(deps Dependencies) *cobra.Command {
 
 	rootCmd.PersistentFlags().String("config", "", "Path to config TOML file")
 	rootCmd.SetVersionTemplate("{{printf \"%s\\n\" .Version}}")
+	rootCmd.AddCommand(initcmd.NewCommand(deps.InitDependencies))
 	rootCmd.AddCommand(capturecmd.NewCommand(deps.CaptureDependencies))
 	rootCmd.AddCommand(capturescmd.NewCommand(deps.CapturesDependencies))
 	rootCmd.AddCommand(templatescmd.NewCommand(deps.TemplateDependencies))
 
 	return rootCmd
+}
+
+func shouldSkipConfigInitialization(cmd *cobra.Command) bool {
+	return cmd != nil && cmd.Name() == "init"
 }

--- a/apps/webhook-cli/internal/cli/root/command_integration_test.go
+++ b/apps/webhook-cli/internal/cli/root/command_integration_test.go
@@ -196,6 +196,8 @@ func TestInitCommandForceOverwritesExistingConfig(t *testing.T) {
 	if err := forceCmd.Execute(); err != nil {
 		t.Fatalf("execute init --force command: %v", err)
 	}
+	output := normalizeCLIOutput(out.String())
+	assertContainsAll(t, output, "Overwrote config file.", configPath)
 
 	updatedContent, err := os.ReadFile(configPath)
 	if err != nil {

--- a/apps/webhook-cli/internal/platform/runtime/config_resolver_test.go
+++ b/apps/webhook-cli/internal/platform/runtime/config_resolver_test.go
@@ -634,6 +634,22 @@ func TestResolveConfigPathRejectsEmptyEnvPath(t *testing.T) {
 	}
 }
 
+func TestResolveConfigPathRejectsEmptyFlagPath(t *testing.T) {
+	command := &cobra.Command{Use: "root"}
+	command.Flags().String("config", "", "")
+	if err := command.Flags().Set("config", "   "); err != nil {
+		t.Fatalf("set config flag: %v", err)
+	}
+
+	_, err := ResolveConfigPath(command)
+	if err == nil {
+		t.Fatalf("expected empty --config path to fail")
+	}
+	if !strings.Contains(err.Error(), "--config") {
+		t.Fatalf("expected flag name in error, got %v", err)
+	}
+}
+
 func TestInitializeConfigUsesResolvedConfigPath(t *testing.T) {
 	command := &cobra.Command{Use: "root"}
 	command.Flags().String("config", "", "")


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds CLI configuration file support with a new `better-webhook init` command that generates a documented TOML config file.

## Key Changes
- Implemented TOML config writer with secure file permissions (0o600) and directory creation
- Added `init` command to generate default config files with `--force` flag for overwrites
- Enhanced config path resolution with clear precedence: `--config` flag > `BETTER_WEBHOOK_CONFIG_PATH` env > default path
- Integrated config initialization skip logic to prevent circular dependency when running `init` command
- Added comprehensive test coverage including unit tests and integration tests
- Created detailed configuration documentation explaining precedence rules and usage

## Code Quality
The implementation follows good practices:
- Proper error handling and validation throughout
- Secure file permissions for config files
- Dependency injection for testability
- Comprehensive test coverage (unit + integration)
- Clear documentation with examples

## Architecture
The config system follows a clean architecture with:
- Adapter layer for TOML reading/writing
- Runtime layer for path resolution and precedence
- CLI layer for user interaction
- All layers properly tested

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The implementation is well-architected with comprehensive test coverage, proper error handling, secure file permissions, and clear documentation. No logical errors, security issues, or architectural concerns were found.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/webhook-cli/internal/adapters/config/toml/writer.go | New TOML config writer with proper permissions (0o600), directory creation, and overwrite protection |
| apps/webhook-cli/internal/cli/init/command.go | Init command with dependency injection, proper error handling, and user-friendly output |
| apps/webhook-cli/internal/platform/runtime/config_resolver.go | Enhanced with `ResolveConfigPath` function following precedence: flag > env > default |
| apps/webhook-cli/internal/cli/root/command.go | Integrated init command with `shouldSkipConfigInitialization` to prevent circular initialization |
| apps/webhook-cli/internal/cli/root/command_integration_test.go | Integration tests validating init command, config path precedence, and force overwrite behavior |
| apps/docs/content/docs/cli/configuration.mdx | Comprehensive configuration documentation with clear precedence rules and examples |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([User runs: better-webhook init]) --> CheckDeps{Dependencies injected?}
    CheckDeps -->|No| Error1[Return: config writer cannot be nil]
    CheckDeps -->|Yes| GetForce[Get --force flag]
    GetForce --> ResolvePath[ResolveConfigPath]
    
    ResolvePath --> CheckFlag{--config flag set?}
    CheckFlag -->|Yes| UseFlag[Use flag value]
    CheckFlag -->|No| CheckEnv{BETTER_WEBHOOK_CONFIG_PATH set?}
    CheckEnv -->|Yes| UseEnv[Use env value]
    CheckEnv -->|No| UseDefault[Use ~/.better-webhook/config.toml]
    
    UseFlag --> ValidatePath[Validate & expand path]
    UseEnv --> ValidatePath
    UseDefault --> ValidatePath
    
    ValidatePath --> WriteConfig[WriteDefaultConfig]
    WriteConfig --> CheckExists{Config file exists?}
    CheckExists -->|Yes + force=false| Error2[Return: file already exists]
    CheckExists -->|Yes + force=true| CreateDir[Create parent directory]
    CheckExists -->|No| CreateDir
    
    CreateDir --> GetHomeDir[Get user home directory]
    GetHomeDir --> RenderTemplate[Render config template]
    RenderTemplate --> WriteFile[Write file with 0o600 permissions]
    WriteFile --> Success([Display success message])
    
    Error1 --> End([End])
    Error2 --> End
    Success --> End
```

<sub>Last reviewed commit: 880f3f0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->