### PR TITLE
Webhook CLI developer experience

### DIFF
--- a/apps/docs/content/docs/cli/commands.mdx
+++ b/apps/docs/content/docs/cli/commands.mdx
@@ -24,6 +24,8 @@ Initialize a default config file:
 better-webhook init
 ```
 
+`init` is optional. The CLI falls back to defaults when no config file exists.
+
 ## capture
 
 Start a standalone server to capture incoming webhooks.
@@ -54,6 +56,12 @@ Captured webhooks are stored locally and can be viewed with `captures list` or r
 ## captures
 
 Manage captured webhooks. This command has several subcommands.
+
+Shared options:
+
+| Option                 | Description                        |
+| ---------------------- | ---------------------------------- |
+| `--captures-dir <dir>` | Directory where captures are stored|
 
 ### captures list
 
@@ -120,6 +128,16 @@ better-webhook captures replay <capture-id> [target-url] [options]
 
 `captures replay` exits non-zero when the target response is HTTP `4xx` or `5xx`.
 
+### replay
+
+Replay is also available as a top-level shortcut for the most common debug loop.
+
+```bash
+better-webhook replay <capture-id> [target-url] [options]
+```
+
+`replay` accepts the same flags and behavior as `captures replay`, including `--captures-dir`.
+
 **Example:**
 
 ```bash
@@ -140,6 +158,12 @@ better-webhook captures replay abc12345 http://localhost:3000/api/webhooks/githu
 ## templates
 
 Manage webhook templates. See [Templates](/docs/cli/templates) for detailed documentation.
+
+Shared options:
+
+| Option                  | Description                                 |
+| ----------------------- | ------------------------------------------- |
+| `--templates-dir <dir>` | Directory where downloaded templates live   |
 
 ### Quick Reference
 

--- a/apps/docs/content/docs/cli/configuration.mdx
+++ b/apps/docs/content/docs/cli/configuration.mdx
@@ -66,7 +66,7 @@ The CLI resolves **which config file to load** in this order:
 | --------------- | -------------------------- | ------------------------------------ | -------------------------- | ----------- |
 | `captures_dir`  | `~/.better-webhook/captures`  | `BETTER_WEBHOOK_CAPTURES_DIR`     | `--captures-dir`           | Directory where captured webhook payloads are stored |
 | `templates_dir` | `~/.better-webhook/templates` | `BETTER_WEBHOOK_TEMPLATES_DIR`    | `--templates-dir`          | Directory where downloaded templates and cache files are stored |
-| `log_level`     | `info`                     | `BETTER_WEBHOOK_LOG_LEVEL`          | command-specific `--verbose` behavior | Default logging verbosity (`debug`, `info`, `warn`, `error`). `debug` enables verbose output by default for `capture`, `captures replay`, and `templates run` unless `--verbose` is explicitly set. |
+| `log_level`     | `info`                     | `BETTER_WEBHOOK_LOG_LEVEL`          | command-specific `--verbose` behavior | Default logging verbosity (`debug`, `info`, `warn`, `error`). `debug` enables verbose output by default for `capture`, `replay`/`captures replay`, and `templates run` unless `--verbose` is explicitly set. |
 
 ## Value Precedence
 

--- a/apps/docs/content/docs/cli/index.mdx
+++ b/apps/docs/content/docs/cli/index.mdx
@@ -62,6 +62,17 @@ Use a terminal-only workflow to capture and replay real webhook traffic:
 
 <Steps>
   <Step>
+    ### Optional: generate a config file
+
+    ```bash
+    better-webhook init
+    ```
+
+    Skip this if you just want the default storage paths under `~/.better-webhook/`.
+
+  </Step>
+
+  <Step>
     ### Start capture server
 
     ```bash
@@ -103,7 +114,7 @@ Use a terminal-only workflow to capture and replay real webhook traffic:
 
     ```bash
     better-webhook captures list
-    better-webhook captures replay <capture-id> \
+    better-webhook replay <capture-id> \
     http://localhost:3000/api/webhooks/github
     ```
 

--- a/apps/docs/scripts/docs-quality-check.mjs
+++ b/apps/docs/scripts/docs-quality-check.mjs
@@ -7,6 +7,7 @@ const docsContentRoot = path.join(docsRoot, "content", "docs");
 const allowedTopLevelCommands = new Set([
   "capture",
   "captures",
+  "replay",
   "templates",
   "--version",
   "version",
@@ -131,7 +132,7 @@ function extractInternalDocsLinks(content) {
 function extractCliCommandMatches(content) {
   const matches = [];
   const commandRegex =
-    /\bbetter-webhook\s+(capture|captures|templates|--version|version)\b[^\n\r`]*/g;
+    /\bbetter-webhook\s+(capture|captures|replay|templates|--version|version)\b[^\n\r`]*/g;
   for (const match of content.matchAll(commandRegex)) {
     const value = match[0].trim();
     const index = match.index ?? 0;
@@ -174,10 +175,6 @@ async function run() {
     if (/\bcaptures\s+(show|search|save-as-template)\b/.test(content)) {
       errors.push(`${sourceFile}: contains unsupported captures subcommands`);
     }
-    if (/\bbetter-webhook\s+replay\b/.test(content)) {
-      errors.push(`${sourceFile}: contains unsupported top-level replay command`);
-    }
-
     for (const { value, index } of extractCliCommandMatches(content)) {
       const tokens = tokenizeCommand(value);
       const topLevel = tokens[1];

--- a/apps/webhook-cli/README.md
+++ b/apps/webhook-cli/README.md
@@ -43,6 +43,9 @@ better-webhook --version
 ## Quick start
 
 ```bash
+# Optional: generate a documented config file first
+better-webhook init
+
 # 1) Start capture server
 better-webhook capture --port 3001
 
@@ -50,7 +53,7 @@ better-webhook capture --port 3001
 better-webhook captures list
 
 # 3) Replay a capture to your app
-better-webhook captures replay <capture-id> http://localhost:3000/api/webhooks/github
+better-webhook replay <capture-id> http://localhost:3000/api/webhooks/github
 ```
 
 ## Commands
@@ -68,26 +71,27 @@ better-webhook capture [--host 127.0.0.1] [--port 3001] [--verbose]
 Manage stored captures.
 
 ```bash
-better-webhook captures list [--limit 20] [--provider github]
-better-webhook captures delete <capture-id> [--force]
-better-webhook captures replay <capture-id> [target-url]
+better-webhook captures [--captures-dir ./tmp/captures] list [--limit 20] [--provider github]
+better-webhook captures [--captures-dir ./tmp/captures] delete <capture-id> [--force]
+better-webhook captures [--captures-dir ./tmp/captures] replay <capture-id> [target-url]
+better-webhook replay [--captures-dir ./tmp/captures] <capture-id> [target-url]
 ```
 
-`captures replay` supports `--base-url`, `--method`, `--header`, `--timeout`, and `--verbose`.
+`replay` and `captures replay` support `--base-url`, `--method`, `--header`, `--timeout`, and `--verbose`.
 
 ### `templates`
 
 Manage and execute templates:
 
 ```bash
-better-webhook templates list
-better-webhook templates download <template-id>
-better-webhook templates list --local
-better-webhook templates delete <template-id>
-better-webhook templates search <query>
-better-webhook templates cache clear
-better-webhook templates clean
-better-webhook templates run <template-id> [target-url]
+better-webhook templates [--templates-dir ./tmp/templates] list
+better-webhook templates [--templates-dir ./tmp/templates] download <template-id>
+better-webhook templates [--templates-dir ./tmp/templates] list --local
+better-webhook templates [--templates-dir ./tmp/templates] delete <template-id>
+better-webhook templates [--templates-dir ./tmp/templates] search <query>
+better-webhook templates [--templates-dir ./tmp/templates] cache clear
+better-webhook templates [--templates-dir ./tmp/templates] clean
+better-webhook templates [--templates-dir ./tmp/templates] run <template-id> [target-url]
 ```
 
 `templates run` supports `--secret`, `--allow-env-placeholders`, `--header`, `--timeout`, and `--verbose`.

--- a/apps/webhook-cli/e2e/e2e_test.go
+++ b/apps/webhook-cli/e2e/e2e_test.go
@@ -55,7 +55,7 @@ func TestCaptureLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list captures: %v\noutput:\n%s", err, listOutput)
 	}
-	if !strings.Contains(listOutput, "Captured webhooks:") {
+	if !strings.Contains(listOutput, "Showing 1 capture(s)") {
 		t.Fatalf("expected captures list output, got:\n%s", listOutput)
 	}
 
@@ -143,11 +143,11 @@ func TestReplayCapturedWebhook(t *testing.T) {
 	}))
 	defer targetServer.Close()
 
-	replayOutput, err := runCLI(t, binaryPath, nil, "--config", configPath, "captures", "replay", id, "--base-url", targetServer.URL)
+	replayOutput, err := runCLI(t, binaryPath, nil, "--config", configPath, "replay", id, "--base-url", targetServer.URL)
 	if err != nil {
 		t.Fatalf("replay command: %v\noutput:\n%s", err, replayOutput)
 	}
-	if !strings.Contains(replayOutput, "Status: 204 No Content") {
+	if !strings.Contains(replayOutput, "204 No Content") {
 		t.Fatalf("expected replay status output, got:\n%s", replayOutput)
 	}
 
@@ -262,9 +262,9 @@ func startCaptureServer(t *testing.T, binaryPath string, configPath string) (*ex
 		case line := <-lines:
 			outputLog.WriteString(line)
 			outputLog.WriteByte('\n')
-			const prefix = "Webhook capture server listening on http://"
-			if strings.Contains(line, prefix) {
-				address := strings.TrimPrefix(strings.TrimSpace(strings.SplitN(line, prefix, 2)[1]), "http://")
+			const prefix = "Listening on http://"
+			if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+				address := strings.TrimSpace(strings.TrimPrefix(line, prefix))
 				return cmd, address, &outputLog, stopStreams
 			}
 		case <-deadline:
@@ -317,7 +317,7 @@ func isInterruptExit(err error) bool {
 
 func extractCaptureID(t *testing.T, listOutput string) string {
 	t.Helper()
-	re := regexp.MustCompile(`(?m)^- ([0-9a-f]{8}) \[`)
+	re := regexp.MustCompile(`(?m)│\s*([0-9a-f]{8})\s*│`)
 	matches := re.FindStringSubmatch(listOutput)
 	if len(matches) < 2 {
 		t.Fatalf("failed to extract capture ID from output:\n%s", listOutput)

--- a/apps/webhook-cli/internal/cli/captures/command.go
+++ b/apps/webhook-cli/internal/cli/captures/command.go
@@ -23,12 +23,23 @@ func NewCommand(deps Dependencies) *cobra.Command {
 		Use:     "captures",
 		Aliases: []string{"c"},
 		Short:   "Manage captured webhooks",
-		RunE:    runGroupCommand,
+		Long: `Manage stored webhook captures.
+
+Shared flags like --captures-dir apply to every captures subcommand.`,
+		Example: `  better-webhook captures list
+  better-webhook captures list --captures-dir ./tmp/captures
+  better-webhook captures replay deadbeef --base-url http://localhost:3000
+  better-webhook captures delete deadbeef --force`,
+		RunE: runGroupCommand,
 	}
 
+	cmd.PersistentFlags().String("captures-dir", "", "Directory where captures are stored")
 	cmd.AddCommand(newListCommand(deps))
 	cmd.AddCommand(newDeleteCommand(deps))
-	cmd.AddCommand(replaycmd.NewCommand(deps.ReplayDependencies))
+	cmd.AddCommand(replaycmd.NewCommandWithOptions(
+		deps.ReplayDependencies,
+		replaycmd.CommandOptions{IncludeCapturesDirFlag: false},
+	))
 
 	return cmd
 }

--- a/apps/webhook-cli/internal/cli/captures/delete_command.go
+++ b/apps/webhook-cli/internal/cli/captures/delete_command.go
@@ -85,7 +85,6 @@ func newDeleteCommand(deps Dependencies) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
-	cmd.Flags().String("captures-dir", "", "Directory where captures are stored")
 	return cmd
 }
 

--- a/apps/webhook-cli/internal/cli/captures/delete_command_test.go
+++ b/apps/webhook-cli/internal/cli/captures/delete_command_test.go
@@ -205,6 +205,7 @@ func setupDeleteCmd(
 		ServiceFactory: testCapturesServiceFactory(t),
 		Prompter:       prompter,
 	})
+	cmd.Flags().String("captures-dir", "", "")
 	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
 	cmd.SetOut(outBuf)

--- a/apps/webhook-cli/internal/cli/captures/list_command.go
+++ b/apps/webhook-cli/internal/cli/captures/list_command.go
@@ -88,7 +88,6 @@ func newListCommand(deps Dependencies) *cobra.Command {
 
 	cmd.Flags().Int("limit", 20, "Maximum number of captures to show")
 	cmd.Flags().String("provider", "", "Filter captures by provider")
-	cmd.Flags().String("captures-dir", "", "Directory where captures are stored")
 
 	return cmd
 }

--- a/apps/webhook-cli/internal/cli/replay/command.go
+++ b/apps/webhook-cli/internal/cli/replay/command.go
@@ -20,7 +20,15 @@ type Dependencies struct {
 	ServiceFactory ServiceFactory
 }
 
+type CommandOptions struct {
+	IncludeCapturesDirFlag bool
+}
+
 func NewCommand(deps Dependencies) *cobra.Command {
+	return NewCommandWithOptions(deps, CommandOptions{IncludeCapturesDirFlag: true})
+}
+
+func NewCommandWithOptions(deps Dependencies, options CommandOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "replay <capture-id> [target-url]",
 		Short: "Replay a captured webhook to a target URL",
@@ -115,7 +123,9 @@ func NewCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("captures-dir", "", "Directory where captures are stored")
+	if options.IncludeCapturesDirFlag {
+		cmd.Flags().String("captures-dir", "", "Directory where captures are stored")
+	}
 	cmd.Flags().String("base-url", runtime.DefaultReplayBaseURL, "Base URL used with the captured request URI when target-url is omitted")
 	cmd.Flags().String("method", "", "Override HTTP method")
 	cmd.Flags().StringArrayP("header", "H", nil, "Add or override header (format: key:value)")

--- a/apps/webhook-cli/internal/cli/root/command.go
+++ b/apps/webhook-cli/internal/cli/root/command.go
@@ -6,6 +6,7 @@ import (
 	capturecmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/capture"
 	capturescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/captures"
 	initcmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/init"
+	replaycmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/replay"
 	templatescmd "github.com/endalk200/better-webhook/apps/webhook-cli/internal/cli/templates"
 	"github.com/endalk200/better-webhook/apps/webhook-cli/internal/platform/runtime"
 )
@@ -21,20 +22,23 @@ type Dependencies struct {
 
 func NewCommand(deps Dependencies) *cobra.Command {
 	initCommand := initcmd.NewCommand(deps.InitDependencies)
+	replayCommand := replaycmd.NewCommand(deps.CapturesDependencies.ReplayDependencies)
 
 	rootCmd := &cobra.Command{
 		Use:   "better-webhook",
-		Short: "Capture and inspect webhook requests locally",
+		Short: "Capture, replay, and test webhooks locally",
 		Long: `A local CLI for capturing webhook requests with high-fidelity storage.
 
-First run:
-  better-webhook init
-Then start capturing:
-  better-webhook capture`,
+Start capturing right away:
+  better-webhook capture --port 3001
+
+Optional: write a documented config file first:
+  better-webhook init`,
 		Example: `  better-webhook init
   better-webhook capture --port 3001
   better-webhook captures list
-  better-webhook captures replay <capture-id> --base-url http://localhost:3000`,
+  better-webhook replay <capture-id> --base-url http://localhost:3000
+  better-webhook templates run github-push http://localhost:3000/api/webhooks/github`,
 		Version:       deps.Version,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -53,6 +57,7 @@ Then start capturing:
 	rootCmd.SetVersionTemplate("{{printf \"%s\\n\" .Version}}")
 	rootCmd.AddCommand(initCommand)
 	rootCmd.AddCommand(capturecmd.NewCommand(deps.CaptureDependencies))
+	rootCmd.AddCommand(replayCommand)
 	rootCmd.AddCommand(capturescmd.NewCommand(deps.CapturesDependencies))
 	rootCmd.AddCommand(templatescmd.NewCommand(deps.TemplateDependencies))
 

--- a/apps/webhook-cli/internal/cli/root/command_integration_test.go
+++ b/apps/webhook-cli/internal/cli/root/command_integration_test.go
@@ -56,8 +56,46 @@ func TestRootCommandShowsHelpByDefault(t *testing.T) {
 	}
 
 	out := output.String()
-	if !strings.Contains(out, "capture") || !strings.Contains(out, "captures") {
+	if !strings.Contains(out, "capture") || !strings.Contains(out, "captures") || !strings.Contains(out, "replay") {
 		t.Fatalf("expected default help output to include capture commands, got %q", out)
+	}
+}
+
+func TestCapturesGroupHelpShowsSharedFlagsAndExamples(t *testing.T) {
+	configPath := writeCommandTestConfig(t, t.TempDir())
+	rootCmd := newTestRootCommand(t)
+	var output bytes.Buffer
+
+	rootCmd.SetOut(&output)
+	rootCmd.SetErr(&output)
+	rootCmd.SetArgs([]string{"--config", configPath, "captures", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected captures help to succeed, got error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "--captures-dir") || !strings.Contains(out, "captures replay deadbeef") {
+		t.Fatalf("expected captures help to show shared flags and examples, got %q", out)
+	}
+}
+
+func TestTemplatesGroupHelpShowsSharedFlagsAndExamples(t *testing.T) {
+	configPath := writeCommandTestConfig(t, t.TempDir())
+	rootCmd := newTestRootCommand(t)
+	var output bytes.Buffer
+
+	rootCmd.SetOut(&output)
+	rootCmd.SetErr(&output)
+	rootCmd.SetArgs([]string{"--config", configPath, "templates", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("expected templates help to succeed, got error: %v", err)
+	}
+
+	out := output.String()
+	if !strings.Contains(out, "--templates-dir") || !strings.Contains(out, "templates run github-push") {
+		t.Fatalf("expected templates help to show shared flags and examples, got %q", out)
 	}
 }
 
@@ -429,7 +467,7 @@ func TestReplayCommandReplaysCaptureByPrefix(t *testing.T) {
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
 	rootCmd.SetErr(&out)
-	rootCmd.SetArgs([]string{"--config", configPath, "captures", "replay", "beadfeed", "--base-url", targetServer.URL})
+	rootCmd.SetArgs([]string{"--config", configPath, "replay", "beadfeed", "--base-url", targetServer.URL})
 
 	if err := rootCmd.Execute(); err != nil {
 		t.Fatalf("execute replay command: %v", err)

--- a/apps/webhook-cli/internal/cli/templates/cache_command.go
+++ b/apps/webhook-cli/internal/cli/templates/cache_command.go
@@ -56,6 +56,5 @@ func newCacheClearCommand(deps Dependencies) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }

--- a/apps/webhook-cli/internal/cli/templates/clean_command.go
+++ b/apps/webhook-cli/internal/cli/templates/clean_command.go
@@ -65,6 +65,5 @@ func newCleanCommand(deps Dependencies) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }

--- a/apps/webhook-cli/internal/cli/templates/clean_command_test.go
+++ b/apps/webhook-cli/internal/cli/templates/clean_command_test.go
@@ -205,6 +205,7 @@ func setupCleanCmd(
 		ServiceFactory: testTemplateServiceFactory(t),
 		Prompter:       prompter,
 	})
+	cmd.Flags().String("templates-dir", "", "")
 	output := &bytes.Buffer{}
 	cmd.SetOut(output)
 	cmd.SetErr(output)

--- a/apps/webhook-cli/internal/cli/templates/command.go
+++ b/apps/webhook-cli/internal/cli/templates/command.go
@@ -26,9 +26,17 @@ func NewCommand(deps Dependencies) *cobra.Command {
 		Use:     "templates",
 		Aliases: []string{"t"},
 		Short:   "Manage webhook templates",
-		RunE:    runTemplateGroupCommand,
+		Long: `Manage remote and local webhook templates.
+
+Shared flags like --templates-dir apply to every templates subcommand.`,
+		Example: `  better-webhook templates list
+  better-webhook templates list --templates-dir ./tmp/templates --local
+  better-webhook templates download github-push
+  better-webhook templates run github-push http://localhost:3000/api/webhooks/github`,
+		RunE: runTemplateGroupCommand,
 	}
 
+	cmd.PersistentFlags().String("templates-dir", "", "Directory where templates are stored")
 	cmd.AddCommand(newListCommand(deps))
 	cmd.AddCommand(newDownloadCommand(deps))
 	cmd.AddCommand(newDeleteCommand(deps))

--- a/apps/webhook-cli/internal/cli/templates/delete_command.go
+++ b/apps/webhook-cli/internal/cli/templates/delete_command.go
@@ -60,7 +60,6 @@ func newDeleteCommand(deps Dependencies) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("force", "f", false, "Skip confirmation prompt")
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }
 

--- a/apps/webhook-cli/internal/cli/templates/delete_command_test.go
+++ b/apps/webhook-cli/internal/cli/templates/delete_command_test.go
@@ -220,6 +220,7 @@ func setupDeleteCmd(
 		ServiceFactory: testTemplateServiceFactory(t),
 		Prompter:       prompter,
 	})
+	cmd.Flags().String("templates-dir", "", "")
 	output := &bytes.Buffer{}
 	cmd.SetOut(output)
 	cmd.SetErr(output)

--- a/apps/webhook-cli/internal/cli/templates/download_command.go
+++ b/apps/webhook-cli/internal/cli/templates/download_command.go
@@ -102,7 +102,6 @@ func newDownloadCommand(deps Dependencies) *cobra.Command {
 
 	cmd.Flags().Bool("all", false, "Download all templates")
 	cmd.Flags().Bool("refresh", false, "Force refresh template index and re-download existing templates")
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }
 

--- a/apps/webhook-cli/internal/cli/templates/list_command.go
+++ b/apps/webhook-cli/internal/cli/templates/list_command.go
@@ -95,6 +95,5 @@ func newListCommand(deps Dependencies) *cobra.Command {
 	cmd.Flags().String("provider", "", "Filter by provider")
 	cmd.Flags().Bool("refresh", false, "Force refresh the template index cache")
 	cmd.Flags().Bool("local", false, "List downloaded local templates instead of remote templates")
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }

--- a/apps/webhook-cli/internal/cli/templates/run_command.go
+++ b/apps/webhook-cli/internal/cli/templates/run_command.go
@@ -106,7 +106,6 @@ func newRunCommand(deps Dependencies) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	cmd.Flags().String("secret", "", "Secret used for provider-specific signing placeholders")
 	cmd.Flags().Bool("allow-env-placeholders", false, "Allow resolving $env:* placeholders from template content")
 	cmd.Flags().StringArrayP("header", "H", nil, "Add or override header (format: key:value)")

--- a/apps/webhook-cli/internal/cli/templates/search_command.go
+++ b/apps/webhook-cli/internal/cli/templates/search_command.go
@@ -75,7 +75,6 @@ func newSearchCommand(deps Dependencies) *cobra.Command {
 	}
 	cmd.Flags().String("provider", "", "Filter by provider")
 	cmd.Flags().Bool("refresh", false, "Force refresh the template index cache")
-	cmd.Flags().String("templates-dir", "", "Directory where templates are stored")
 	return cmd
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Improve CLI discoverability and ergonomics by adding a top-level `replay` command, promoting shared flags, and clarifying `init` documentation.

The `init` command was presented as a mandatory first step, despite the CLI functioning with default paths. Shared storage flags (`--captures-dir`, `--templates-dir`) were duplicated and only discoverable at subcommand levels, hindering their use. Additionally, `replay` is a core developer loop command that lacked a convenient top-level shortcut. These changes address these friction points to streamline the developer experience.

---
<p><a href="https://cursor.com/agents/bc-c6ae8fad-25b2-4760-a8ae-233c6f2379ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6ae8fad-25b2-4760-a8ae-233c6f2379ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->