### PR TITLE
Refactor webhook handlers and enhance documentation and examples

### DIFF
--- a/apps/docs/content/docs/sdk/opentelemetry.mdx
+++ b/apps/docs/content/docs/sdk/opentelemetry.mdx
@@ -7,6 +7,10 @@ description: Add OpenTelemetry traces and metrics to better-webhook handlers.
 
 Use `@better-webhook/otel` to emit traces and metrics from webhook processing.
 
+Runnable example in this repo:
+
+- `apps/examples/express-github-otel-example` for a complete Express plus OpenTelemetry runtime setup
+
 ## Install
 
 ```bash

--- a/apps/docs/content/docs/sdk/providers.mdx
+++ b/apps/docs/content/docs/sdk/providers.mdx
@@ -555,25 +555,45 @@ Ragie uses HMAC-SHA256 signatures sent in the `X-Signature` header.
 import { recall } from "@better-webhook/recall";
 import {
   participant_events_join,
+  participant_events_chat_message,
   transcript_data,
   bot_done,
 } from "@better-webhook/recall/events";
 
 const webhook = recall({ secret: process.env.RECALL_WEBHOOK_SECRET })
   .event(participant_events_join, async (payload) => {
-    console.log(payload.data.participant.name);
+    const participantEvent = payload.data;
+
+    console.log(participantEvent.participant.name);
+  })
+  .event(participant_events_chat_message, async (payload) => {
+    const participantEvent = payload.data;
+    const message = participantEvent.data;
+
+    console.log(message.text);
   })
   .event(transcript_data, async (payload) => {
-    console.log(payload.data.words.length);
+    const transcript = payload.data;
+
+    console.log(transcript.words.length);
   })
   .event(bot_done, async (payload) => {
-    console.log(payload.data.code);
+    const botStatus = payload.data;
+
+    console.log(botStatus.code);
   });
 ```
 
 <Callout type="info">
-  Recall events use an envelope where the SDK reads event type from `body.event`
-  and validates the unwrapped payload from `body.data`.
+  Recall events use an envelope where the SDK reads the event type from
+  `body.event` and passes the unwrapped `body.data` object to your handler as
+  `payload`.
+</Callout>
+
+<Callout type="info">
+  Recall handler payloads still include nested provider fields such as
+  `payload.data.participant`, `payload.data.words`, and `payload.data.code`.
+  The SDK unwraps the outer envelope, not the inner Recall event schema.
 </Callout>
 
 ### Events
@@ -643,9 +663,9 @@ import {
 
 **Key payload fields:**
 
-- `data.participant` - Participant identity and metadata
+- `data.participant` - Participant identity and metadata on the handler payload
 - `data.timestamp` - Absolute and relative event timestamps
-- `data.data` - Event-specific data (chat content for `chat_message`, otherwise often `null`)
+- `data.data` - Event-specific nested data such as chat content for `chat_message`
 - `realtime_endpoint` / `participant_events` / `recording` / `bot` - Related Recall resources
 
 #### transcript.*
@@ -671,7 +691,7 @@ import {
 
 **Key payload fields:**
 
-- `data.words` - Transcript word segments with relative timestamps
+- `data.words` - Transcript word segments with relative timestamps on the handler payload
 - `data.participant` - Speaker information
 - `transcript` / `recording` / `bot` - Related Recall resources
 
@@ -709,7 +729,7 @@ import {
 
 **Key payload fields:**
 
-- `data.code` - Machine-readable bot status code
+- `data.code` - Machine-readable bot status code on the handler payload
 - `data.sub_code` - Optional additional reason code
 - `data.updated_at` - Status update timestamp
 - `bot` - Bot resource metadata

--- a/apps/docs/content/docs/sdk/replay-idempotency.mdx
+++ b/apps/docs/content/docs/sdk/replay-idempotency.mdx
@@ -7,6 +7,11 @@ description: Prevent duplicate webhook processing with replay protection.
 
 Enable replay protection when duplicate webhook deliveries could create unwanted side effects.
 
+Runnable examples in this repo:
+
+- `apps/examples/express-github-inmemory-replay-example` for a process-local replay store
+- `apps/examples/express-github-prisma-replay-example` for a durable Postgres-backed replay store implemented with Prisma
+
 Core replay protection uses provider-specific replay keys:
 
 - GitHub: `x-github-delivery`

--- a/apps/examples/express-example/README.md
+++ b/apps/examples/express-example/README.md
@@ -1,15 +1,29 @@
 # Express Example
 
-A simple Express server demonstrating `@better-webhook/github`,
-`@better-webhook/ragie`, `@better-webhook/recall`, and
-`@better-webhook/express`.
+An Express app showing the default multi-provider setup for `@better-webhook/express`.
 
-This example also boots a local OpenTelemetry SDK with console exporters so spans and metrics are visible immediately while you send test webhooks.
+## Choose This Example If...
+
+- you want the simplest Express starting point
+- you want one webhook file per provider
+- you want to compare GitHub, Ragie, Stripe, and Recall in one app
+
+## What It Demonstrates
+
+- one Express route per provider under `src/webhooks`
+- raw-body verification with `express.raw({ type: "application/json" })`
+- representative event handling for GitHub, Ragie, Stripe, and Recall
+
+Representative events in this app:
+
+- GitHub: `push`, `pull_request`, `issues`
+- Ragie: `document_status_updated`, `connection_sync_finished`, `entity_extracted`
+- Stripe: `charge.failed`, `checkout.session.completed`, `payment_intent.succeeded`
+- Recall: `participant_events.join`, `participant_events.chat_message`, `transcript.data`, `bot.done`
 
 ## Quick Start
 
 ```bash
-# From the repository root
 pnpm install
 pnpm --filter @better-webhook/express-example dev
 ```
@@ -18,33 +32,35 @@ Server URL: `http://localhost:3001`
 
 ## Configuration
 
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+RAGIE_WEBHOOK_SECRET=your-ragie-secret
+STRIPE_WEBHOOK_SECRET=your-stripe-secret
+RECALL_WEBHOOK_SECRET=your-recall-secret
+PORT=3001
+```
+
 | Variable                | Required | Description                             |
 | ----------------------- | -------- | --------------------------------------- |
 | `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
 | `RAGIE_WEBHOOK_SECRET`  | Yes      | Secret used to verify Ragie signatures  |
+| `STRIPE_WEBHOOK_SECRET` | Yes      | Secret used to verify Stripe signatures |
 | `RECALL_WEBHOOK_SECRET` | Yes      | Secret used to verify Recall signatures |
 | `PORT`                  | No       | Override the default port (`3001`)      |
 
-Example:
-
-```bash
-GITHUB_WEBHOOK_SECRET=your-github-secret \
-RAGIE_WEBHOOK_SECRET=your-ragie-secret \
-RECALL_WEBHOOK_SECRET=your-recall-whsec-secret \
-pnpm --filter @better-webhook/express-example dev
-```
-
 ## Endpoints
 
-- `POST /webhooks/github` - GitHub webhook endpoint
-- `POST /webhooks/ragie` - Ragie webhook endpoint
-- `POST /webhooks/recall` - Recall.ai webhook endpoint
-- `GET /health` - Health check
+- `POST /webhooks/github` verifies and handles GitHub webhook events
+- `POST /webhooks/ragie` verifies and handles Ragie webhook events
+- `POST /webhooks/stripe` verifies and handles Stripe webhook events
+- `POST /webhooks/recall` verifies and handles Recall webhook events
+- `GET /health` returns `{ status, timestamp }` so you can confirm the app is up
 
-## Signed Testing
+## Try It
 
-Unsigned requests are rejected (`401`) because verification is required by
-default. Sign test payloads with the same secret configured in your env vars.
+Send a signed GitHub `push` event:
 
 ```bash
 SECRET="your-github-secret"
@@ -59,26 +75,34 @@ curl -X POST "http://localhost:3001/webhooks/github" \
   -d "$PAYLOAD"
 ```
 
-For dev-only unsigned testing, use a custom provider configured with
-`verification: "disabled"`. Do not use disabled verification in production.
+Expected result:
 
-## Replay Strategy Notes
+- the request succeeds with a verified response
+- the app logs `GitHub push received`
+- the app logs `GitHub webhook processed`
 
-This example demonstrates manual in-memory dedupe on selected handlers:
+## File Layout
 
-- GitHub and Recall use `context.deliveryId`
-- Ragie uses `payload.nonce` from the signed envelope
+- `src/index.ts` creates the app and mounts routes
+- `src/webhooks/github.ts` handles GitHub events
+- `src/webhooks/ragie.ts` handles Ragie events
+- `src/webhooks/stripe.ts` handles Stripe events
+- `src/webhooks/recall.ts` handles Recall events
 
-For production, use a shared replay store so duplicate detection works across
-multiple instances.
+## Recall Note
 
-For side-by-side examples of manual checks, `createInMemoryReplayStore`, and a
-custom `ReplayStore`, see `apps/examples/nextjs-example/app/api/webhooks`.
+Recall sends `{ event, data }`, but your handler receives the unwrapped `data` object. That payload still contains Recall-specific nested fields such as `payload.data.participant` and `payload.data.code`.
+
+## Advanced Topics
+
+This example stays intentionally minimal. For deeper guidance, use the canonical SDK docs:
+
+- `apps/docs/content/docs/sdk/providers.mdx`
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/opentelemetry.mdx`
 
 ## Troubleshooting
 
-- No telemetry output: wait a few seconds for the metric export interval, then check the server console for span and metric output.
-- `401` responses: verify secrets match the sender and your local env vars.
-- Signature mismatch: sign the exact raw payload bytes sent in `curl`.
-- Express raw body: keep `express.raw({ type: "application/json" })` on webhook routes.
-- Replays after restart: expected with in-memory dedupe; switch to shared storage.
+- `401` usually means the configured secret does not match the sender.
+- Express routes must keep `express.raw({ type: "application/json" })` for signature verification.
+- Sign the exact raw payload bytes you send.

--- a/apps/examples/express-example/README.md
+++ b/apps/examples/express-example/README.md
@@ -37,8 +37,8 @@ Create your env vars before sending requests:
 ```bash
 GITHUB_WEBHOOK_SECRET=your-github-secret
 RAGIE_WEBHOOK_SECRET=your-ragie-secret
-STRIPE_WEBHOOK_SECRET=your-stripe-secret
-RECALL_WEBHOOK_SECRET=your-recall-secret
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret
+RECALL_WEBHOOK_SECRET=whsec_your-recall-secret
 PORT=3001
 ```
 

--- a/apps/examples/express-example/package.json
+++ b/apps/examples/express-example/package.json
@@ -12,15 +12,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-webhook/core": "workspace:*",
     "@better-webhook/express": "workspace:*",
     "@better-webhook/github": "workspace:*",
-    "@better-webhook/otel": "workspace:*",
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "^0.203.0",
-    "@opentelemetry/sdk-metrics": "^2.1.0",
-    "@opentelemetry/sdk-node": "^0.203.0",
-    "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@better-webhook/recall": "workspace:*",
     "@better-webhook/ragie": "workspace:*",
     "express": "^4.21.2",

--- a/apps/examples/express-example/src/index.ts
+++ b/apps/examples/express-example/src/index.ts
@@ -5,7 +5,14 @@ import { recallHandler } from "./webhooks/recall.js";
 import { stripeHandler } from "./webhooks/stripe.js";
 
 const app = express();
-const port = Number(process.env.PORT ?? "3001");
+const portValue = process.env.PORT ?? "3001";
+const port = Number(portValue);
+
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError(
+    `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+  );
+}
 
 app.post(
   "/webhooks/github",

--- a/apps/examples/express-example/src/index.ts
+++ b/apps/examples/express-example/src/index.ts
@@ -1,387 +1,51 @@
 import express from "express";
-import { NodeSDK } from "@opentelemetry/sdk-node";
-import {
-  ConsoleMetricExporter,
-  PeriodicExportingMetricReader,
-} from "@opentelemetry/sdk-metrics";
-import { ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
-import { createInMemoryReplayStore } from "@better-webhook/core";
-import { toExpress } from "@better-webhook/express";
-import { github } from "@better-webhook/github";
-import { issues, pull_request, push } from "@better-webhook/github/events";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
-import { recall } from "@better-webhook/recall";
-import {
-  bot_breakout_room_closed,
-  bot_breakout_room_entered,
-  bot_breakout_room_left,
-  bot_breakout_room_opened,
-  bot_call_ended,
-  bot_done,
-  bot_fatal,
-  bot_in_call_not_recording,
-  bot_in_call_recording,
-  bot_in_waiting_room,
-  bot_joining_call,
-  bot_recording_permission_allowed,
-  bot_recording_permission_denied,
-  participant_events_chat_message,
-  participant_events_join,
-  participant_events_leave,
-  participant_events_screenshare_off,
-  participant_events_screenshare_on,
-  participant_events_speech_off,
-  participant_events_speech_on,
-  participant_events_update,
-  participant_events_webcam_off,
-  participant_events_webcam_on,
-  transcript_data,
-  transcript_partial_data,
-} from "@better-webhook/recall/events";
-import { ragie } from "@better-webhook/ragie";
-import {
-  connection_sync_finished,
-  document_status_updated,
-  entity_extracted,
-} from "@better-webhook/ragie/events";
-import { stripe } from "@better-webhook/stripe";
-import {
-  charge_failed,
-  checkout_session_completed,
-  payment_intent_succeeded,
-} from "@better-webhook/stripe/events";
-
-const otelSdk = new NodeSDK({
-  traceExporter: new ConsoleSpanExporter(),
-  metricReader: new PeriodicExportingMetricReader({
-    exporter: new ConsoleMetricExporter(),
-    exportIntervalMillis: 5_000,
-  }),
-});
-
-await otelSdk.start();
+import { githubHandler } from "./webhooks/github.js";
+import { ragieHandler } from "./webhooks/ragie.js";
+import { recallHandler } from "./webhooks/recall.js";
+import { stripeHandler } from "./webhooks/stripe.js";
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const port = Number(process.env.PORT ?? "3001");
 
-const githubReplayStore = createInMemoryReplayStore();
-const ragieReplayStore = createInMemoryReplayStore();
-const stripeReplayStore = createInMemoryReplayStore();
-const recallReplayStore = createInMemoryReplayStore();
-
-const otelInstrumentation = createOpenTelemetryInstrumentation({
-  includeEventTypeAttribute: true,
-});
-
-// Create a GitHub webhook handler with observability
-const githubWebhook = github()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: githubReplayStore })
-  .event(push, async (payload, context) => {
-    console.log("📦 Push event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Received at: ${context.receivedAt.toISOString()}`);
-    console.log(`   Repository: ${payload.repository.full_name}`);
-    console.log(`   Branch: ${payload.ref}`);
-    console.log(`   Commits: ${payload.commits.length}`);
-    payload.commits.forEach((commit) => {
-      console.log(`   - ${commit.message} (${commit.id.slice(0, 7)})`);
-    });
-  })
-  .event(pull_request, async (payload, context) => {
-    console.log("🔀 Pull request event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Action: ${payload.action}`);
-    console.log(
-      `   PR #${payload.pull_request.number}: ${payload.pull_request.title}`,
-    );
-    console.log(`   State: ${payload.pull_request.state}`);
-  })
-  .event(issues, async (payload, context) => {
-    console.log("🎫 Issue event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Action: ${payload.action}`);
-    console.log(`   Issue #${payload.issue.number}: ${payload.issue.title}`);
-    console.log(`   State: ${payload.issue.state}`);
-  })
-  .onError(async (error, context) => {
-    console.error("❌ Webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("🔐 Verification failed:", reason);
-  });
-
-// Create a Ragie webhook handler with observability
-const ragieWebhook = ragie()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: ragieReplayStore })
-  .event(document_status_updated, async (payload) => {
-    console.log("📄 Document status updated!");
-    console.log(`   Document ID: ${payload.document_id}`);
-    console.log(`   Status: ${payload.status}`);
-    console.log(`   Partition: ${payload.partition}`);
-  })
-  .event(connection_sync_finished, async (payload) => {
-    console.log("✅ Connection sync finished!");
-    console.log(`   Connection ID: ${payload.connection_id}`);
-    console.log(`   Sync ID: ${payload.sync_id}`);
-    console.log(`   Partition: ${payload.partition}`);
-  })
-  .event(entity_extracted, async (payload) => {
-    console.log("🔍 Entity extraction completed!");
-    console.log(`   Document ID: ${payload.document_id}`);
-    console.log(`   Partition: ${payload.partition}`);
-  })
-  .onError(async (error, context) => {
-    console.error("❌ Ragie webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("🔐 Ragie verification failed:", reason);
-  });
-
-// Create a Recall webhook handler with observability
-const recallWebhook = recall()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: recallReplayStore })
-  .event(participant_events_join, async (payload, context) => {
-    console.log("🟢 Recall participant joined");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_leave, async (payload, context) => {
-    console.log("🔴 Recall participant left");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_update, async (payload, context) => {
-    console.log("📝 Recall participant updated");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_speech_on, async (payload, context) => {
-    console.log("🗣️ Recall participant speech on");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_speech_off, async (payload, context) => {
-    console.log("🔇 Recall participant speech off");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_webcam_on, async (payload, context) => {
-    console.log("📷 Recall participant webcam on");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_webcam_off, async (payload, context) => {
-    console.log("📷 Recall participant webcam off");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_screenshare_on, async (payload, context) => {
-    console.log("🖥️ Recall participant screenshare on");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_screenshare_off, async (payload, context) => {
-    console.log("🖥️ Recall participant screenshare off");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-  })
-  .event(participant_events_chat_message, async (payload, context) => {
-    console.log("💬 Recall participant chat message");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Participant: ${payload.data.participant.name}`);
-    console.log(`   Text: ${payload.data.data.text}`);
-  })
-  .event(transcript_data, async (payload, context) => {
-    console.log("📜 Recall transcript data");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Word count: ${payload.data.words.length}`);
-  })
-  .event(transcript_partial_data, async (payload, context) => {
-    console.log("🧩 Recall transcript partial data");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   Word count: ${payload.data.words.length}`);
-  })
-  .event(bot_joining_call, async (payload, context) => {
-    console.log("🤖 Recall bot joining call");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_in_waiting_room, async (payload, context) => {
-    console.log("🤖 Recall bot in waiting room");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_in_call_not_recording, async (payload, context) => {
-    console.log("🤖 Recall bot in call not recording");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_recording_permission_allowed, async (payload, context) => {
-    console.log("🤖 Recall bot recording permission allowed");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_recording_permission_denied, async (payload, context) => {
-    console.log("🤖 Recall bot recording permission denied");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_in_call_recording, async (payload, context) => {
-    console.log("🤖 Recall bot in call recording");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_call_ended, async (payload, context) => {
-    console.log("🤖 Recall bot call ended");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_done, async (payload, context) => {
-    console.log("🤖 Recall bot done");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_fatal, async (payload, context) => {
-    console.log("🤖 Recall bot fatal");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_breakout_room_entered, async (payload, context) => {
-    console.log("🤖 Recall bot breakout room entered");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_breakout_room_left, async (payload, context) => {
-    console.log("🤖 Recall bot breakout room left");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_breakout_room_opened, async (payload, context) => {
-    console.log("🤖 Recall bot breakout room opened");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .event(bot_breakout_room_closed, async (payload, context) => {
-    console.log("🤖 Recall bot breakout room closed");
-    console.log(`   Event: ${context.eventType}`);
-    console.log(`   BotId: ${payload.bot.id}`);
-  })
-  .onError(async (error, context) => {
-    console.error("❌ Recall webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("🔐 Recall verification failed:", reason);
-  });
-
-// Create a Stripe webhook handler with observability
-const stripeWebhook = stripe()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: stripeReplayStore })
-  .event(charge_failed, async (payload) => {
-    console.log("💳 Stripe charge failed");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   Charge ID: ${payload.data.object.id}`);
-    console.log(`   Amount: ${payload.data.object.amount}`);
-    console.log(`   Failure: ${payload.data.object.failure_code}`);
-  })
-  .event(checkout_session_completed, async (payload) => {
-    console.log("🧾 Stripe checkout session completed");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   Session ID: ${payload.data.object.id}`);
-    console.log(`   Payment status: ${payload.data.object.payment_status}`);
-  })
-  .event(payment_intent_succeeded, async (payload) => {
-    console.log("✅ Stripe payment intent succeeded");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   PaymentIntent ID: ${payload.data.object.id}`);
-    console.log(`   Latest charge: ${payload.data.object.latest_charge}`);
-  })
-  .onError(async (error, context) => {
-    console.error("❌ Stripe webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("🔐 Stripe verification failed:", reason);
-  });
-
-// Mount the webhook handlers
-// Note: express.raw() is required to get the raw body for signature verification
 app.post(
   "/webhooks/github",
   express.raw({ type: "application/json" }),
-  toExpress(githubWebhook, {
-    secret: process.env.GITHUB_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed GitHub ${eventType} event`);
-    },
-  }),
+  githubHandler,
 );
 
 app.post(
   "/webhooks/ragie",
   express.raw({ type: "application/json" }),
-  toExpress(ragieWebhook, {
-    secret: process.env.RAGIE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Ragie ${eventType} event`);
-    },
-  }),
+  ragieHandler,
 );
 
 app.post(
   "/webhooks/stripe",
   express.raw({ type: "application/json" }),
-  toExpress(stripeWebhook, {
-    secret: process.env.STRIPE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Stripe ${eventType} event`);
-    },
-  }),
+  stripeHandler,
 );
 
 app.post(
   "/webhooks/recall",
   express.raw({ type: "application/json" }),
-  toExpress(recallWebhook, {
-    secret: process.env.RECALL_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Recall ${eventType} event`);
-    },
-  }),
+  recallHandler,
 );
 
-// Health check endpoint
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
-// Start the server
-app.listen(PORT, () => {
-  console.log(`
-🚀 Express webhook server running!
-   
-   Webhook endpoints:
-   - GitHub: http://localhost:${PORT}/webhooks/github
-   - Ragie:  http://localhost:${PORT}/webhooks/ragie
-   - Stripe: http://localhost:${PORT}/webhooks/stripe
-   - Recall: http://localhost:${PORT}/webhooks/recall
-   
-   Health check: http://localhost:${PORT}/health
-
-   Environment variables:
-   - GITHUB_WEBHOOK_SECRET (for GitHub webhooks)
-   - RAGIE_WEBHOOK_SECRET (for Ragie webhooks)
-   - STRIPE_WEBHOOK_SECRET (for Stripe webhooks)
-   - RECALL_WEBHOOK_SECRET (for Recall webhooks)
-
-   To test with ngrok:
-   1. ngrok http ${PORT}
-   2. Configure webhooks with the ngrok URL + /webhooks/[provider]
-  `);
+app.listen(port, () => {
+  console.log(`Express example listening on http://localhost:${port}`);
+  console.log("Endpoints:");
+  console.log(`- POST http://localhost:${port}/webhooks/github`);
+  console.log(`- POST http://localhost:${port}/webhooks/ragie`);
+  console.log(`- POST http://localhost:${port}/webhooks/stripe`);
+  console.log(`- POST http://localhost:${port}/webhooks/recall`);
+  console.log(`- GET  http://localhost:${port}/health`);
+  console.log("Required env vars:");
+  console.log("- GITHUB_WEBHOOK_SECRET");
+  console.log("- RAGIE_WEBHOOK_SECRET");
+  console.log("- STRIPE_WEBHOOK_SECRET");
+  console.log("- RECALL_WEBHOOK_SECRET");
 });

--- a/apps/examples/express-example/src/webhooks/github.ts
+++ b/apps/examples/express-example/src/webhooks/github.ts
@@ -1,0 +1,45 @@
+import { toExpress } from "@better-webhook/express";
+import { github } from "@better-webhook/github";
+import { issues, pull_request, push } from "@better-webhook/github/events";
+
+const githubWebhook = github()
+  .event(push, async (payload, context) => {
+    console.log("GitHub push received", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
+    });
+  })
+  .event(pull_request, async (payload, context) => {
+    console.log("GitHub pull request received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.pull_request.number,
+      title: payload.pull_request.title,
+    });
+  })
+  .event(issues, async (payload, context) => {
+    console.log("GitHub issue received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.issue.number,
+      title: payload.issue.title,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("GitHub webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("GitHub verification failed", { reason });
+  });
+
+export const githubHandler = toExpress(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", { eventType });
+  },
+});

--- a/apps/examples/express-example/src/webhooks/ragie.ts
+++ b/apps/examples/express-example/src/webhooks/ragie.ts
@@ -1,0 +1,46 @@
+import { toExpress } from "@better-webhook/express";
+import { ragie } from "@better-webhook/ragie";
+import {
+  connection_sync_finished,
+  document_status_updated,
+  entity_extracted,
+} from "@better-webhook/ragie/events";
+
+const ragieWebhook = ragie()
+  .event(document_status_updated, async (payload) => {
+    console.log("Ragie document status updated", {
+      documentId: payload.document_id,
+      status: payload.status,
+      partition: payload.partition,
+    });
+  })
+  .event(connection_sync_finished, async (payload) => {
+    console.log("Ragie connection sync finished", {
+      connectionId: payload.connection_id,
+      syncId: payload.sync_id,
+      partition: payload.partition,
+    });
+  })
+  .event(entity_extracted, async (payload) => {
+    console.log("Ragie entity extracted", {
+      entityId: payload.entity_id,
+      documentId: payload.document_id,
+      instructionId: payload.instruction_id,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Ragie webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Ragie verification failed", { reason });
+  });
+
+export const ragieHandler = toExpress(ragieWebhook, {
+  secret: process.env.RAGIE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Ragie webhook processed", { eventType });
+  },
+});

--- a/apps/examples/express-example/src/webhooks/recall.ts
+++ b/apps/examples/express-example/src/webhooks/recall.ts
@@ -1,0 +1,66 @@
+import { toExpress } from "@better-webhook/express";
+import { recall } from "@better-webhook/recall";
+import {
+  bot_done,
+  participant_events_chat_message,
+  participant_events_join,
+  transcript_data,
+} from "@better-webhook/recall/events";
+
+const recallWebhook = recall()
+  .event(participant_events_join, async (payload, context) => {
+    const participantEvent = payload.data;
+
+    console.log("Recall participant joined", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+    });
+  })
+  .event(participant_events_chat_message, async (payload, context) => {
+    const participantEvent = payload.data;
+    const message = participantEvent.data;
+
+    console.log("Recall chat message received", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+      text: message.text,
+      to: message.to,
+    });
+  })
+  .event(transcript_data, async (payload, context) => {
+    const transcript = payload.data;
+
+    console.log("Recall transcript segment received", {
+      eventType: context.eventType,
+      participantId: transcript.participant.id,
+      wordCount: transcript.words.length,
+    });
+  })
+  .event(bot_done, async (payload, context) => {
+    const botStatus = payload.data;
+
+    console.log("Recall bot finished", {
+      eventType: context.eventType,
+      botId: payload.bot.id,
+      code: botStatus.code,
+      subCode: botStatus.sub_code,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Recall webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Recall verification failed", { reason });
+  });
+
+export const recallHandler = toExpress(recallWebhook, {
+  secret: process.env.RECALL_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Recall webhook processed", { eventType });
+  },
+});

--- a/apps/examples/express-example/src/webhooks/stripe.ts
+++ b/apps/examples/express-example/src/webhooks/stripe.ts
@@ -1,0 +1,47 @@
+import { toExpress } from "@better-webhook/express";
+import { stripe } from "@better-webhook/stripe";
+import {
+  charge_failed,
+  checkout_session_completed,
+  payment_intent_succeeded,
+} from "@better-webhook/stripe/events";
+
+const stripeWebhook = stripe()
+  .event(charge_failed, async (payload) => {
+    console.log("Stripe charge failed", {
+      eventId: payload.id,
+      chargeId: payload.data.object.id,
+      amount: payload.data.object.amount,
+      failureCode: payload.data.object.failure_code,
+    });
+  })
+  .event(checkout_session_completed, async (payload) => {
+    console.log("Stripe checkout completed", {
+      eventId: payload.id,
+      sessionId: payload.data.object.id,
+      paymentStatus: payload.data.object.payment_status,
+    });
+  })
+  .event(payment_intent_succeeded, async (payload) => {
+    console.log("Stripe payment intent succeeded", {
+      eventId: payload.id,
+      paymentIntentId: payload.data.object.id,
+      latestCharge: payload.data.object.latest_charge,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Stripe webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Stripe verification failed", { reason });
+  });
+
+export const stripeHandler = toExpress(stripeWebhook, {
+  secret: process.env.STRIPE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Stripe webhook processed", { eventType });
+  },
+});

--- a/apps/examples/express-github-inmemory-replay-example/README.md
+++ b/apps/examples/express-github-inmemory-replay-example/README.md
@@ -1,0 +1,98 @@
+# Express GitHub In-Memory Replay Example
+
+An Express app showing GitHub replay protection with `createInMemoryReplayStore()`.
+
+## Choose This Example If...
+
+- you want the fastest local replay-protection demo
+- you only need one provider and one route
+- you want to watch a duplicate delivery return `409`
+
+## What This Example Focuses On
+
+- replay protection configured with `.withReplayProtection(...)`
+- GitHub delivery ids as the replay key
+- a process-local store that is easy to understand in one file
+
+This example handles the GitHub `push` event.
+
+## Quick Start
+
+```bash
+pnpm install
+pnpm --filter @better-webhook/express-github-inmemory-replay-example dev
+```
+
+Server URL: `http://localhost:3003`
+
+If you are running multiple examples at once, override `PORT`. `3003` is also used by `nestjs-example`.
+
+## Configuration
+
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+PORT=3003
+```
+
+| Variable                | Required | Description                             |
+| ----------------------- | -------- | --------------------------------------- |
+| `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
+| `PORT`                  | No       | Override the default port (`3003`)      |
+
+## Endpoints
+
+- `POST /webhooks/github` verifies the GitHub request, checks the replay store, and handles the event
+- `GET /health` returns `{ status, timestamp }` so you can confirm the app is up
+
+## Expected Behavior
+
+Use one delivery id for the first request and reuse it for the duplicate.
+
+```bash
+SECRET="your-github-secret"
+DELIVERY_ID="replay-demo-1"
+PAYLOAD='{"ref":"refs/heads/main","repository":{"id":1,"name":"test","full_name":"org/test","private":false},"commits":[{"id":"abc123","message":"Replay demo","timestamp":"2024-01-01T00:00:00Z","url":"https://example.com","author":{"name":"Test","email":"test@example.com"},"committer":{"name":"Test","email":"test@example.com"}}],"head_commit":null,"before":"000","after":"abc","created":false,"deleted":false,"forced":false,"base_ref":null,"compare":"https://example.com","pusher":{"name":"test"},"sender":{"login":"test","id":1,"type":"User"}}'
+SIGNATURE=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.* //')
+
+curl -i -X POST "http://localhost:3003/webhooks/github" \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -H "X-GitHub-Delivery: $DELIVERY_ID" \
+  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+  -d "$PAYLOAD"
+```
+
+Expected flow:
+
+- the first request succeeds and logs `GitHub push accepted`
+- the same request with the same `X-GitHub-Delivery` returns `409`
+- changing `DELIVERY_ID` to a new value makes the request succeed again
+
+## Limitations
+
+The in-memory replay store is process-local.
+
+- restarting the server clears replay history
+- running multiple app instances does not share replay state
+- this is great for local development and tests, not for durable production replay protection
+
+## File Layout
+
+- `src/index.ts` creates the app and mounts the GitHub route
+- `src/webhooks/github.ts` configures GitHub verification and replay protection
+
+## Canonical Docs
+
+Use the main docs for broader replay/idempotency guidance:
+
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/providers.mdx`
+
+## Troubleshooting
+
+- `401` usually means the configured secret does not match the sender.
+- `409` on the second request is the expected duplicate behavior.
+- Express must keep `express.raw({ type: "application/json" })` on the webhook route.
+- Sign the exact raw payload bytes you send.

--- a/apps/examples/express-github-inmemory-replay-example/eslint.config.js
+++ b/apps/examples/express-github-inmemory-replay-example/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@better-webhook/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/apps/examples/express-github-inmemory-replay-example/package.json
+++ b/apps/examples/express-github-inmemory-replay-example/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@better-webhook/express-github-inmemory-replay-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Express GitHub in-memory replay example for better-webhook",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "echo 'No build needed for example'",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@better-webhook/core": "workspace:*",
+    "@better-webhook/express": "workspace:*",
+    "@better-webhook/github": "workspace:*",
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@better-webhook/eslint-config": "workspace:*",
+    "@better-webhook/typescript-config": "workspace:*",
+    "@types/express": "^5.0.0",
+    "@types/node": "^24.3.1",
+    "eslint": "^9.35.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/apps/examples/express-github-inmemory-replay-example/src/index.ts
+++ b/apps/examples/express-github-inmemory-replay-example/src/index.ts
@@ -1,0 +1,26 @@
+import express from "express";
+import { githubHandler } from "./webhooks/github.js";
+
+const app = express();
+const port = Number(process.env.PORT ?? "3003");
+
+app.post(
+  "/webhooks/github",
+  express.raw({ type: "application/json" }),
+  githubHandler,
+);
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+app.listen(port, () => {
+  console.log(
+    `Express GitHub in-memory replay example listening on http://localhost:${port}`,
+  );
+  console.log("Endpoints:");
+  console.log(`- POST http://localhost:${port}/webhooks/github`);
+  console.log(`- GET  http://localhost:${port}/health`);
+  console.log("Required env vars:");
+  console.log("- GITHUB_WEBHOOK_SECRET");
+});

--- a/apps/examples/express-github-inmemory-replay-example/src/index.ts
+++ b/apps/examples/express-github-inmemory-replay-example/src/index.ts
@@ -2,7 +2,14 @@ import express from "express";
 import { githubHandler } from "./webhooks/github.js";
 
 const app = express();
-const port = Number(process.env.PORT ?? "3003");
+const portValue = process.env.PORT ?? "3003";
+const port = Number(portValue);
+
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError(
+    `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+  );
+}
 
 app.post(
   "/webhooks/github",

--- a/apps/examples/express-github-inmemory-replay-example/src/webhooks/github.ts
+++ b/apps/examples/express-github-inmemory-replay-example/src/webhooks/github.ts
@@ -1,0 +1,42 @@
+import { createInMemoryReplayStore } from "@better-webhook/core";
+import { toExpress } from "@better-webhook/express";
+import { github } from "@better-webhook/github";
+import { push } from "@better-webhook/github/events";
+
+const replayStore = createInMemoryReplayStore();
+
+const githubWebhook = github()
+  .withReplayProtection({
+    store: replayStore,
+  })
+  .event(push, async (payload, context) => {
+    console.log("GitHub push accepted", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("GitHub replay example error", {
+      deliveryId: context.deliveryId,
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason, headers) => {
+    console.error("GitHub verification failed", {
+      reason,
+      deliveryId: headers["x-github-delivery"],
+    });
+  });
+
+export const githubHandler = toExpress(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", {
+      eventType,
+      replayStore: "memory",
+    });
+  },
+});

--- a/apps/examples/express-github-inmemory-replay-example/tsconfig.json
+++ b/apps/examples/express-github-inmemory-replay-example/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@better-webhook/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/examples/express-github-otel-example/README.md
+++ b/apps/examples/express-github-otel-example/README.md
@@ -1,0 +1,97 @@
+# Express GitHub OpenTelemetry Example
+
+An Express app showing GitHub webhook instrumentation with `@better-webhook/otel` plus a local OpenTelemetry runtime.
+
+## Choose This Example If...
+
+- you want local visibility into spans and metrics
+- you want to see builder-level instrumentation in a small app
+- you want a GitHub-only telemetry example before wiring a collector
+
+## What This Example Focuses On
+
+- builder instrumentation with `.instrument(createOpenTelemetryInstrumentation(...))`
+- local SDK startup before the server begins handling requests
+- console-exported spans and metrics for a GitHub `push` event
+
+## Quick Start
+
+```bash
+pnpm install
+pnpm --filter @better-webhook/express-github-otel-example dev
+```
+
+Server URL: `http://localhost:3004`
+
+If you are running multiple examples at once, override `PORT`. `3004` is also used by `hono-example`.
+
+## Configuration
+
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+PORT=3004
+```
+
+| Variable                | Required | Description                             |
+| ----------------------- | -------- | --------------------------------------- |
+| `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
+| `PORT`                  | No       | Override the default port (`3004`)      |
+
+## Endpoints
+
+- `POST /webhooks/github` verifies and handles GitHub webhook events
+- `GET /health` returns `{ status, timestamp }` for app liveness only; it does not validate exporter or collector health
+
+## Expected Behavior
+
+Send a signed GitHub `push` event:
+
+```bash
+SECRET="your-github-secret"
+PAYLOAD='{"ref":"refs/heads/main","repository":{"id":1,"name":"test","full_name":"org/test","private":false},"commits":[{"id":"abc123","message":"Telemetry demo","timestamp":"2024-01-01T00:00:00Z","url":"https://example.com","author":{"name":"Test","email":"test@example.com"},"committer":{"name":"Test","email":"test@example.com"}}],"head_commit":null,"before":"000","after":"abc","created":false,"deleted":false,"forced":false,"base_ref":null,"compare":"https://example.com","pusher":{"name":"test"},"sender":{"login":"test","id":1,"type":"User"}}'
+SIGNATURE=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.* //')
+
+curl -i -X POST "http://localhost:3004/webhooks/github" \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -H "X-GitHub-Delivery: telemetry-demo-1" \
+  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+  -d "$PAYLOAD"
+```
+
+Expected result:
+
+- the request succeeds with a verified response
+- the app logs `GitHub push received`
+- the app logs `GitHub webhook processed`
+- you see a console-exported `better-webhook.process` span
+- you see periodic metric export output such as `better_webhook.requests`, `better_webhook.completed`, and `better_webhook.duration`
+
+## Limitations And Production Scope
+
+This example is optimized for local visibility, not production telemetry architecture.
+
+- it uses local SDK setup and console exporters so you can see telemetry immediately
+- it does not configure OTLP exporters, a collector, or deployment-specific resource conventions
+- `deliveryId` and other high-cardinality attributes stay off by default
+
+## File Layout
+
+- `src/index.ts` starts telemetry, boots Express, and flushes on shutdown
+- `src/telemetry.ts` configures the OpenTelemetry SDK and console exporters
+- `src/webhooks/github.ts` handles GitHub events and adds instrumentation
+
+## Canonical Docs
+
+Use the main docs for broader telemetry guidance:
+
+- `apps/docs/content/docs/sdk/opentelemetry.mdx`
+- `apps/docs/content/docs/sdk/providers.mdx`
+
+## Troubleshooting
+
+- If you only see handler logs, make sure the telemetry SDK started before the server began listening.
+- Express must keep `express.raw({ type: "application/json" })` on the webhook route.
+- Sign the exact raw payload bytes you send.

--- a/apps/examples/express-github-otel-example/eslint.config.js
+++ b/apps/examples/express-github-otel-example/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@better-webhook/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/apps/examples/express-github-otel-example/package.json
+++ b/apps/examples/express-github-otel-example/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@better-webhook/express-github-otel-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Express GitHub OpenTelemetry example for better-webhook",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "echo 'No build needed for example'",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@better-webhook/express": "workspace:*",
+    "@better-webhook/github": "workspace:*",
+    "@better-webhook/otel": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/resources": "^2.6.1",
+    "@opentelemetry/sdk-metrics": "^2.6.1",
+    "@opentelemetry/sdk-node": "^0.214.0",
+    "@opentelemetry/sdk-trace-base": "^2.6.1",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "@better-webhook/eslint-config": "workspace:*",
+    "@better-webhook/typescript-config": "workspace:*",
+    "@types/express": "^5.0.0",
+    "@types/node": "^24.3.1",
+    "eslint": "^9.35.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/apps/examples/express-github-otel-example/src/index.ts
+++ b/apps/examples/express-github-otel-example/src/index.ts
@@ -1,0 +1,45 @@
+import express from "express";
+import { stopTelemetry, startTelemetry } from "./telemetry.js";
+import { githubHandler } from "./webhooks/github.js";
+
+const app = express();
+const port = Number(process.env.PORT ?? "3004");
+
+app.post(
+  "/webhooks/github",
+  express.raw({ type: "application/json" }),
+  githubHandler,
+);
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+const shutdown = async (signal: string): Promise<void> => {
+  console.log(`Received ${signal}, shutting down telemetry example`);
+  await stopTelemetry();
+  process.exit(0);
+};
+
+process.on("SIGINT", () => {
+  void shutdown("SIGINT");
+});
+
+process.on("SIGTERM", () => {
+  void shutdown("SIGTERM");
+});
+
+void (async () => {
+  await startTelemetry();
+
+  app.listen(port, () => {
+    console.log(
+      `Express GitHub OpenTelemetry example listening on http://localhost:${port}`,
+    );
+    console.log("Endpoints:");
+    console.log(`- POST http://localhost:${port}/webhooks/github`);
+    console.log(`- GET  http://localhost:${port}/health`);
+    console.log("Required env vars:");
+    console.log("- GITHUB_WEBHOOK_SECRET");
+  });
+})();

--- a/apps/examples/express-github-otel-example/src/index.ts
+++ b/apps/examples/express-github-otel-example/src/index.ts
@@ -3,7 +3,14 @@ import { stopTelemetry, startTelemetry } from "./telemetry.js";
 import { githubHandler } from "./webhooks/github.js";
 
 const app = express();
-const port = Number(process.env.PORT ?? "3004");
+const portValue = process.env.PORT ?? "3004";
+const port = Number(portValue);
+
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError(
+    `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+  );
+}
 
 app.post(
   "/webhooks/github",

--- a/apps/examples/express-github-otel-example/src/telemetry.ts
+++ b/apps/examples/express-github-otel-example/src/telemetry.ts
@@ -8,7 +8,7 @@ import {
   ConsoleSpanExporter,
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
-import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 let telemetrySdk: NodeSDK | undefined;
 
@@ -19,7 +19,7 @@ export async function startTelemetry(): Promise<void> {
 
   telemetrySdk = new NodeSDK({
     resource: resourceFromAttributes({
-      [SEMRESATTRS_SERVICE_NAME]: "better-webhook-express-github-otel-example",
+      [ATTR_SERVICE_NAME]: "better-webhook-express-github-otel-example",
     }),
     spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
     metricReader: new PeriodicExportingMetricReader({

--- a/apps/examples/express-github-otel-example/src/telemetry.ts
+++ b/apps/examples/express-github-otel-example/src/telemetry.ts
@@ -1,0 +1,43 @@
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  ConsoleMetricExporter,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+let telemetrySdk: NodeSDK | undefined;
+
+export async function startTelemetry(): Promise<void> {
+  if (telemetrySdk) {
+    return;
+  }
+
+  telemetrySdk = new NodeSDK({
+    resource: resourceFromAttributes({
+      [SEMRESATTRS_SERVICE_NAME]: "better-webhook-express-github-otel-example",
+    }),
+    spanProcessors: [new SimpleSpanProcessor(new ConsoleSpanExporter())],
+    metricReader: new PeriodicExportingMetricReader({
+      exporter: new ConsoleMetricExporter(),
+      exportIntervalMillis: 5_000,
+    }),
+  });
+
+  await telemetrySdk.start();
+  console.log("OpenTelemetry SDK started");
+}
+
+export async function stopTelemetry(): Promise<void> {
+  if (!telemetrySdk) {
+    return;
+  }
+
+  await telemetrySdk.shutdown();
+  telemetrySdk = undefined;
+  console.log("OpenTelemetry SDK stopped");
+}

--- a/apps/examples/express-github-otel-example/src/webhooks/github.ts
+++ b/apps/examples/express-github-otel-example/src/webhooks/github.ts
@@ -1,0 +1,56 @@
+import { trace } from "@opentelemetry/api";
+import { toExpress } from "@better-webhook/express";
+import { github } from "@better-webhook/github";
+import { push } from "@better-webhook/github/events";
+import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
+
+const githubWebhook = github()
+  .instrument(
+    createOpenTelemetryInstrumentation({
+      includeEventTypeAttribute: true,
+    }),
+  )
+  .event(push, async (payload, contextData) => {
+    const tracer = trace.getTracer("express-github-otel-example");
+
+    const span = tracer.startSpan("github.push.handler");
+    try {
+      span.setAttribute("github.repository", payload.repository.full_name);
+      span.setAttribute(
+        "github.delivery_id",
+        contextData.deliveryId ?? "unknown",
+      );
+
+      console.log("GitHub push received", {
+        deliveryId: contextData.deliveryId,
+        repository: payload.repository.full_name,
+        branch: payload.ref,
+        commits: payload.commits.length,
+      });
+    } finally {
+      span.end();
+    }
+  })
+  .onError(async (error, contextData) => {
+    console.error("GitHub telemetry example error", {
+      deliveryId: contextData.deliveryId,
+      eventType: contextData.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason, headers) => {
+    console.error("GitHub verification failed", {
+      reason,
+      deliveryId: headers["x-github-delivery"],
+    });
+  });
+
+export const githubHandler = toExpress(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", {
+      eventType,
+      telemetry: "otel",
+    });
+  },
+});

--- a/apps/examples/express-github-otel-example/tsconfig.json
+++ b/apps/examples/express-github-otel-example/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@better-webhook/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/examples/express-github-prisma-replay-example/README.md
+++ b/apps/examples/express-github-prisma-replay-example/README.md
@@ -1,0 +1,100 @@
+# Express GitHub Prisma Replay Example
+
+An Express app showing GitHub replay protection with a Postgres-backed replay store implemented locally with Prisma.
+
+## Choose This Example If...
+
+- you need durable replay protection backed by Postgres
+- you want to see a concrete `ReplayStore` implementation
+- you want duplicate detection that survives process restarts
+
+## What This Example Focuses On
+
+- replay protection configured with `.withReplayProtection(...)`
+- a local Prisma-backed `ReplayStore`
+- durable duplicate detection for the GitHub `push` event
+
+## Quick Start
+
+This example expects an existing Postgres database.
+
+```bash
+pnpm install
+pnpm --filter @better-webhook/express-github-prisma-replay-example prisma:generate
+pnpm --filter @better-webhook/express-github-prisma-replay-example prisma:push
+pnpm --filter @better-webhook/express-github-prisma-replay-example dev
+```
+
+Server URL: `http://localhost:3005`
+
+## Configuration
+
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/better_webhook
+PORT=3005
+```
+
+| Variable                | Required | Description                             |
+| ----------------------- | -------- | --------------------------------------- |
+| `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
+| `DATABASE_URL`          | Yes      | Postgres connection string for Prisma   |
+| `PORT`                  | No       | Override the default port (`3005`)      |
+
+## Endpoints
+
+- `POST /webhooks/github` verifies the GitHub request, checks the replay store, and handles the event
+- `GET /health` runs a database check before returning `{ status, timestamp }`, so it confirms both app liveness and DB reachability
+
+## Expected Behavior
+
+Send a signed GitHub `push` event:
+
+```bash
+SECRET="your-github-secret"
+DELIVERY_ID="prisma-replay-demo-1"
+PAYLOAD='{"ref":"refs/heads/main","repository":{"id":1,"name":"test","full_name":"org/test","private":false},"commits":[{"id":"abc123","message":"Prisma replay demo","timestamp":"2024-01-01T00:00:00Z","url":"https://example.com","author":{"name":"Test","email":"test@example.com"},"committer":{"name":"Test","email":"test@example.com"}}],"head_commit":null,"before":"000","after":"abc","created":false,"deleted":false,"forced":false,"base_ref":null,"compare":"https://example.com","pusher":{"name":"test"},"sender":{"login":"test","id":1,"type":"User"}}'
+SIGNATURE=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.* //')
+
+curl -i -X POST "http://localhost:3005/webhooks/github" \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -H "X-GitHub-Delivery: $DELIVERY_ID" \
+  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
+  -d "$PAYLOAD"
+```
+
+Expected flow:
+
+- the first request succeeds and logs `GitHub push accepted`
+- the same request with the same `X-GitHub-Delivery` returns `409`
+- restarting the server does not clear replay history because the delivery id is stored in Postgres
+- changing `DELIVERY_ID` to a new value makes the request succeed again
+
+## Limitations And Production Scope
+
+This example demonstrates one way to implement the `ReplayStore` contract. It is not trying to become a reusable Prisma package or a full persistence architecture.
+
+## File Layout
+
+- `prisma/schema.prisma` defines the datasource and replay record model
+- `src/prisma.ts` creates the Prisma client
+- `src/replay-store.ts` implements the Prisma-backed `ReplayStore`
+- `src/webhooks/github.ts` configures GitHub verification and replay protection
+- `src/index.ts` mounts routes and health checks
+
+## Canonical Docs
+
+Use the main docs for broader replay/idempotency guidance:
+
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/providers.mdx`
+
+## Troubleshooting
+
+- If `prisma db push` fails, verify that `DATABASE_URL` points to a reachable Postgres database.
+- `401` usually means the configured secret does not match the sender.
+- `409` on the second request is the expected duplicate behavior.
+- Express must keep `express.raw({ type: "application/json" })` on the webhook route.

--- a/apps/examples/express-github-prisma-replay-example/README.md
+++ b/apps/examples/express-github-prisma-replay-example/README.md
@@ -17,6 +17,7 @@ An Express app showing GitHub replay protection with a Postgres-backed replay st
 ## Quick Start
 
 This example expects an existing Postgres database.
+Set `DATABASE_URL` before running `prisma:push`, and set `GITHUB_WEBHOOK_SECRET` before sending signed requests.
 
 ```bash
 pnpm install

--- a/apps/examples/express-github-prisma-replay-example/eslint.config.js
+++ b/apps/examples/express-github-prisma-replay-example/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@better-webhook/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/apps/examples/express-github-prisma-replay-example/package.json
+++ b/apps/examples/express-github-prisma-replay-example/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@better-webhook/express-github-prisma-replay-example",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Express GitHub Prisma replay example for better-webhook",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "start": "tsx src/index.ts",
+    "build": "echo 'No build needed for example'",
+    "lint": "eslint .",
+    "check-types": "tsc --noEmit",
+    "prisma:generate": "prisma generate",
+    "prisma:push": "prisma db push"
+  },
+  "dependencies": {
+    "@better-webhook/core": "workspace:*",
+    "@better-webhook/express": "workspace:*",
+    "@better-webhook/github": "workspace:*",
+    "@prisma/client": "^6.19.3",
+    "express": "^4.21.2",
+    "prisma": "^6.19.3"
+  },
+  "devDependencies": {
+    "@better-webhook/eslint-config": "workspace:*",
+    "@better-webhook/typescript-config": "workspace:*",
+    "@types/express": "^5.0.0",
+    "@types/node": "^24.3.1",
+    "eslint": "^9.35.0",
+    "tsx": "^4.20.5",
+    "typescript": "^5.6.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/apps/examples/express-github-prisma-replay-example/prisma/schema.prisma
+++ b/apps/examples/express-github-prisma-replay-example/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model ReplayRecord {
+  key       String   @id @map("key")
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("replay_records")
+}

--- a/apps/examples/express-github-prisma-replay-example/src/index.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/index.ts
@@ -3,7 +3,14 @@ import { prisma } from "./prisma.js";
 import { githubHandler } from "./webhooks/github.js";
 
 const app = express();
-const port = Number(process.env.PORT ?? "3005");
+const portValue = process.env.PORT ?? "3005";
+const port = Number(portValue);
+
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError(
+    `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+  );
+}
 
 app.post(
   "/webhooks/github",
@@ -12,29 +19,18 @@ app.post(
 );
 
 app.get("/health", async (_req, res) => {
-  await prisma.$queryRaw`SELECT 1`;
-  res.json({ status: "ok", timestamp: new Date().toISOString() });
+  const timestamp = new Date().toISOString();
+
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: "ok", timestamp });
+  } catch (error) {
+    console.error("Health check failed", error);
+    res.status(503).json({ status: "error", timestamp });
+  }
 });
 
-const shutdown = async (): Promise<void> => {
-  await prisma.$disconnect();
-};
-
-process.on("beforeExit", () => {
-  void shutdown();
-});
-
-process.on("SIGINT", () => {
-  void shutdown();
-  process.exit(0);
-});
-
-process.on("SIGTERM", () => {
-  void shutdown();
-  process.exit(0);
-});
-
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(
     `Express GitHub Prisma replay example listening on http://localhost:${port}`,
   );
@@ -44,4 +40,49 @@ app.listen(port, () => {
   console.log("Required env vars:");
   console.log("- GITHUB_WEBHOOK_SECRET");
   console.log("- DATABASE_URL");
+});
+
+let shuttingDown: Promise<void> | undefined;
+
+const shutdown = async (signal: string): Promise<void> => {
+  if (shuttingDown) {
+    return shuttingDown;
+  }
+
+  shuttingDown = (async () => {
+    console.log(`Received ${signal}, shutting down Prisma replay example`);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+
+      await prisma.$disconnect();
+      process.exit(0);
+    } catch (error) {
+      console.error("Failed to shut down cleanly", error);
+      process.exit(1);
+    }
+  })();
+
+  return shuttingDown;
+};
+
+process.once("beforeExit", () => {
+  void prisma.$disconnect();
+});
+
+process.once("SIGINT", () => {
+  void shutdown("SIGINT");
+});
+
+process.once("SIGTERM", () => {
+  void shutdown("SIGTERM");
 });

--- a/apps/examples/express-github-prisma-replay-example/src/index.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/index.ts
@@ -1,0 +1,47 @@
+import express from "express";
+import { prisma } from "./prisma.js";
+import { githubHandler } from "./webhooks/github.js";
+
+const app = express();
+const port = Number(process.env.PORT ?? "3005");
+
+app.post(
+  "/webhooks/github",
+  express.raw({ type: "application/json" }),
+  githubHandler,
+);
+
+app.get("/health", async (_req, res) => {
+  await prisma.$queryRaw`SELECT 1`;
+  res.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+const shutdown = async (): Promise<void> => {
+  await prisma.$disconnect();
+};
+
+process.on("beforeExit", () => {
+  void shutdown();
+});
+
+process.on("SIGINT", () => {
+  void shutdown();
+  process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+  void shutdown();
+  process.exit(0);
+});
+
+app.listen(port, () => {
+  console.log(
+    `Express GitHub Prisma replay example listening on http://localhost:${port}`,
+  );
+  console.log("Endpoints:");
+  console.log(`- POST http://localhost:${port}/webhooks/github`);
+  console.log(`- GET  http://localhost:${port}/health`);
+  console.log("Required env vars:");
+  console.log("- GITHUB_WEBHOOK_SECRET");
+  console.log("- DATABASE_URL");
+});

--- a/apps/examples/express-github-prisma-replay-example/src/prisma.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  var prismaReplayExampleClient: PrismaClient | undefined;
+}
+
+export const prisma =
+  globalThis.prismaReplayExampleClient ??
+  new PrismaClient({
+    log: ["warn", "error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prismaReplayExampleClient = prisma;
+}

--- a/apps/examples/express-github-prisma-replay-example/src/replay-store.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/replay-store.ts
@@ -1,0 +1,48 @@
+import { Prisma } from "@prisma/client";
+import type { ReplayReserveResult, ReplayStore } from "@better-webhook/core";
+import { prisma } from "./prisma.js";
+
+export class PrismaReplayStore implements ReplayStore {
+  async reserve(
+    key: string,
+    inFlightTtlSeconds: number,
+  ): Promise<ReplayReserveResult> {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + inFlightTtlSeconds * 1000);
+
+    const inserted = await prisma.$executeRaw`
+      INSERT INTO replay_records (key, expires_at, created_at, updated_at)
+      VALUES (${key}, ${expiresAt}, NOW(), NOW())
+      ON CONFLICT (key) DO UPDATE
+      SET expires_at = EXCLUDED.expires_at,
+          updated_at = NOW()
+      WHERE replay_records.expires_at <= ${now}
+    `;
+
+    return inserted > 0 ? "reserved" : "duplicate";
+  }
+
+  async commit(key: string, ttlSeconds: number): Promise<void> {
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000);
+
+    await prisma.replayRecord.update({
+      where: { key },
+      data: { expiresAt },
+    });
+  }
+
+  async release(key: string): Promise<void> {
+    try {
+      await prisma.replayRecord.delete({ where: { key } });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2025"
+      ) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+}

--- a/apps/examples/express-github-prisma-replay-example/src/webhooks/github.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/webhooks/github.ts
@@ -1,0 +1,42 @@
+import { toExpress } from "@better-webhook/express";
+import { github } from "@better-webhook/github";
+import { push } from "@better-webhook/github/events";
+import { PrismaReplayStore } from "../replay-store.js";
+
+const replayStore = new PrismaReplayStore();
+
+const githubWebhook = github()
+  .withReplayProtection({
+    store: replayStore,
+  })
+  .event(push, async (payload, context) => {
+    console.log("GitHub push accepted", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("GitHub Prisma replay example error", {
+      deliveryId: context.deliveryId,
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason, headers) => {
+    console.error("GitHub verification failed", {
+      reason,
+      deliveryId: headers["x-github-delivery"],
+    });
+  });
+
+export const githubHandler = toExpress(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", {
+      eventType,
+      replayStore: "prisma-postgres",
+    });
+  },
+});

--- a/apps/examples/express-github-prisma-replay-example/tsconfig.json
+++ b/apps/examples/express-github-prisma-replay-example/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@better-webhook/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/examples/hono-example/README.md
+++ b/apps/examples/hono-example/README.md
@@ -39,8 +39,8 @@ Create your env vars before sending requests:
 ```bash
 GITHUB_WEBHOOK_SECRET=your-github-secret
 RAGIE_WEBHOOK_SECRET=your-ragie-secret
-STRIPE_WEBHOOK_SECRET=your-stripe-secret
-RECALL_WEBHOOK_SECRET=your-recall-secret
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret
+RECALL_WEBHOOK_SECRET=whsec_your-recall-secret
 PORT=3004
 ```
 

--- a/apps/examples/hono-example/README.md
+++ b/apps/examples/hono-example/README.md
@@ -1,47 +1,68 @@
 # Hono Example
 
-A simple Hono app demonstrating `@better-webhook/github`,
-`@better-webhook/ragie`, `@better-webhook/recall`, and `@better-webhook/hono`.
+A Hono app showing the default multi-provider setup for `@better-webhook/hono`.
+
+## Choose This Example If...
+
+- you want minimal Hono route wiring
+- you want one webhook file per provider
+- you want to compare GitHub, Ragie, Stripe, and Recall in one app
+
+## What It Demonstrates
+
+- one Hono route per provider under `src/webhooks`
+- adapter-based request handling with `toHonoNode(...)`
+- representative event handling for GitHub, Ragie, Stripe, and Recall
+
+Representative events in this app:
+
+- GitHub: `push`, `pull_request`, `issues`
+- Ragie: `document_status_updated`, `connection_sync_finished`, `entity_extracted`
+- Stripe: `charge.failed`, `checkout.session.completed`, `payment_intent.succeeded`
+- Recall: `participant_events.join`, `participant_events.chat_message`, `transcript.data`, `bot.done`
 
 ## Quick Start
 
 ```bash
-# From the repository root
 pnpm install
 pnpm --filter @better-webhook/hono-example dev
 ```
 
 Server URL: `http://localhost:3004`
 
+If you are running multiple examples at once, override `PORT`. `3004` is also used by `express-github-otel-example`.
+
 ## Configuration
+
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+RAGIE_WEBHOOK_SECRET=your-ragie-secret
+STRIPE_WEBHOOK_SECRET=your-stripe-secret
+RECALL_WEBHOOK_SECRET=your-recall-secret
+PORT=3004
+```
 
 | Variable                | Required | Description                             |
 | ----------------------- | -------- | --------------------------------------- |
 | `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
 | `RAGIE_WEBHOOK_SECRET`  | Yes      | Secret used to verify Ragie signatures  |
+| `STRIPE_WEBHOOK_SECRET` | Yes      | Secret used to verify Stripe signatures |
 | `RECALL_WEBHOOK_SECRET` | Yes      | Secret used to verify Recall signatures |
 | `PORT`                  | No       | Override the default port (`3004`)      |
 
-Example:
-
-```bash
-GITHUB_WEBHOOK_SECRET=your-github-secret \
-RAGIE_WEBHOOK_SECRET=your-ragie-secret \
-RECALL_WEBHOOK_SECRET=your-recall-whsec-secret \
-pnpm --filter @better-webhook/hono-example dev
-```
-
 ## Endpoints
 
-- `POST /webhooks/github` - GitHub webhook endpoint
-- `POST /webhooks/ragie` - Ragie webhook endpoint
-- `POST /webhooks/recall` - Recall.ai webhook endpoint
-- `GET /health` - Health check
+- `POST /webhooks/github` verifies and handles GitHub webhook events
+- `POST /webhooks/ragie` verifies and handles Ragie webhook events
+- `POST /webhooks/stripe` verifies and handles Stripe webhook events
+- `POST /webhooks/recall` verifies and handles Recall webhook events
+- `GET /health` returns `{ status, timestamp }` so you can confirm the app is up
 
-## Signed Testing
+## Try It
 
-Unsigned requests are rejected (`401`) because verification is required by
-default. Sign test payloads with the same secret configured in your env vars.
+Send a signed GitHub `push` event:
 
 ```bash
 SECRET="your-github-secret"
@@ -56,25 +77,34 @@ curl -X POST "http://localhost:3004/webhooks/github" \
   -d "$PAYLOAD"
 ```
 
-For dev-only unsigned testing, use a custom provider configured with
-`verification: "disabled"`. Do not use disabled verification in production.
+Expected result:
 
-## Replay Strategy Notes
+- the request succeeds with a verified response
+- the app logs `GitHub push received`
+- the app logs `GitHub webhook processed`
 
-This example demonstrates manual in-memory dedupe on selected handlers:
+## File Layout
 
-- GitHub and Recall use `context.deliveryId`
-- Ragie uses `payload.nonce` from the signed envelope
+- `src/index.ts` creates the Hono app and mounts routes
+- `src/webhooks/github.ts` handles GitHub events
+- `src/webhooks/ragie.ts` handles Ragie events
+- `src/webhooks/stripe.ts` handles Stripe events
+- `src/webhooks/recall.ts` handles Recall events
 
-For production, use a shared replay store so duplicate detection works across
-multiple instances.
+## Recall Note
 
-For side-by-side examples of manual checks, `createInMemoryReplayStore`, and a
-custom `ReplayStore`, see `apps/examples/nextjs-example/app/api/webhooks`.
+The Recall handlers intentionally rely on type inference. Your handler receives unwrapped `body.data`, but nested properties such as `payload.data.participant` still come from Recall's event schema.
+
+## Advanced Topics
+
+This example keeps replay protection and telemetry out of the default flow. For those topics, use the canonical SDK docs:
+
+- `apps/docs/content/docs/sdk/providers.mdx`
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/opentelemetry.mdx`
 
 ## Troubleshooting
 
-- `401` responses: verify secrets match the sender and your local env vars.
-- Signature mismatch: sign the exact raw payload bytes sent in `curl`.
-- Raw body handling: avoid consuming `c.req.raw` before the adapter runs.
-- Replays after restart: expected with in-memory dedupe; switch to shared storage.
+- `401` usually means the configured secret does not match the sender.
+- Do not read or consume the raw request before `toHonoNode(...)` runs.
+- Sign the exact raw payload bytes you send.

--- a/apps/examples/hono-example/package.json
+++ b/apps/examples/hono-example/package.json
@@ -12,10 +12,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-webhook/core": "workspace:*",
     "@better-webhook/github": "workspace:*",
     "@better-webhook/hono": "workspace:*",
-    "@better-webhook/otel": "workspace:*",
     "@better-webhook/recall": "workspace:*",
     "@better-webhook/ragie": "workspace:*",
     "@hono/node-server": "^1.19.7",

--- a/apps/examples/hono-example/src/index.ts
+++ b/apps/examples/hono-example/src/index.ts
@@ -6,7 +6,14 @@ import { recallHandler } from "./webhooks/recall.js";
 import { stripeHandler } from "./webhooks/stripe.js";
 
 const app = new Hono();
-const port = Number(process.env.PORT ?? "3004");
+const portValue = process.env.PORT ?? "3004";
+const port = Number(portValue);
+
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError(
+    `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+  );
+}
 
 app.post("/webhooks/github", githubHandler);
 app.post("/webhooks/ragie", ragieHandler);

--- a/apps/examples/hono-example/src/index.ts
+++ b/apps/examples/hono-example/src/index.ts
@@ -1,257 +1,17 @@
 import { serve } from "@hono/node-server";
-import { createInMemoryReplayStore } from "@better-webhook/core";
-import { github } from "@better-webhook/github";
-import { issues, pull_request, push } from "@better-webhook/github/events";
-import { toHonoNode } from "@better-webhook/hono";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
-import { recall } from "@better-webhook/recall";
-import {
-  bot_breakout_room_closed,
-  bot_breakout_room_entered,
-  bot_breakout_room_left,
-  bot_breakout_room_opened,
-  bot_call_ended,
-  bot_done,
-  bot_fatal,
-  bot_in_call_not_recording,
-  bot_in_call_recording,
-  bot_in_waiting_room,
-  bot_joining_call,
-  bot_recording_permission_allowed,
-  bot_recording_permission_denied,
-  participant_events_chat_message,
-  participant_events_join,
-  participant_events_leave,
-  participant_events_screenshare_off,
-  participant_events_screenshare_on,
-  participant_events_speech_off,
-  participant_events_speech_on,
-  participant_events_update,
-  participant_events_webcam_off,
-  participant_events_webcam_on,
-  transcript_data,
-  transcript_partial_data,
-} from "@better-webhook/recall/events";
-import { ragie } from "@better-webhook/ragie";
-import {
-  connection_sync_finished,
-  document_status_updated,
-  entity_extracted,
-} from "@better-webhook/ragie/events";
-import { stripe } from "@better-webhook/stripe";
-import {
-  charge_failed,
-  checkout_session_completed,
-  payment_intent_succeeded,
-} from "@better-webhook/stripe/events";
 import { Hono } from "hono";
+import { githubHandler } from "./webhooks/github.js";
+import { ragieHandler } from "./webhooks/ragie.js";
+import { recallHandler } from "./webhooks/recall.js";
+import { stripeHandler } from "./webhooks/stripe.js";
 
 const app = new Hono();
 const port = Number(process.env.PORT ?? "3004");
 
-const githubReplayStore = createInMemoryReplayStore();
-const ragieReplayStore = createInMemoryReplayStore();
-const stripeReplayStore = createInMemoryReplayStore();
-const recallReplayStore = createInMemoryReplayStore();
-
-const otelInstrumentation = createOpenTelemetryInstrumentation({
-  includeEventTypeAttribute: true,
-});
-
-const logRecallParticipantEvent = async (
-  payload: { data: { participant: { name: string | null } } },
-  context: { eventType: string },
-) => {
-  console.log(
-    `Recall ${context.eventType}: ${payload.data.participant.name ?? "unknown participant"}`,
-  );
-};
-
-const logRecallBotCodeEvent = async (
-  payload: { data: { code: string } },
-  context: { eventType: string },
-) => {
-  console.log(`Recall ${context.eventType}: ${payload.data.code}`);
-};
-
-const githubWebhook = github()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: githubReplayStore })
-  .event(push, async (payload, context) => {
-    console.log("Push event received");
-    console.log(`Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`Repository: ${payload.repository.full_name}`);
-    console.log(`Branch: ${payload.ref}`);
-    console.log(`Commits: ${payload.commits.length}`);
-  })
-  .event(pull_request, async (payload, context) => {
-    console.log("Pull request event received");
-    console.log(`Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`Action: ${payload.action}`);
-    console.log(
-      `PR #${payload.pull_request.number}: ${payload.pull_request.title}`,
-    );
-  })
-  .event(issues, async (payload, context) => {
-    console.log("Issue event received");
-    console.log(`Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`Action: ${payload.action}`);
-    console.log(`Issue #${payload.issue.number}: ${payload.issue.title}`);
-  })
-  .onError(async (error, context) => {
-    console.error("GitHub webhook error:", error.message);
-    console.error("Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("GitHub verification failed:", reason);
-  });
-
-const ragieWebhook = ragie()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: ragieReplayStore })
-  .event(document_status_updated, async (payload) => {
-    console.log("Document status updated");
-    console.log(`Document ID: ${payload.document_id}`);
-    console.log(`Status: ${payload.status}`);
-    console.log(`Partition: ${payload.partition}`);
-  })
-  .event(connection_sync_finished, async (payload) => {
-    console.log("Connection sync finished");
-    console.log(`Connection ID: ${payload.connection_id}`);
-    console.log(`Sync ID: ${payload.sync_id}`);
-    console.log(`Partition: ${payload.partition}`);
-  })
-  .event(entity_extracted, async (payload) => {
-    console.log("Entity extraction completed");
-    console.log(`Document ID: ${payload.document_id}`);
-    console.log(`Partition: ${payload.partition}`);
-  })
-  .onError(async (error, context) => {
-    console.error("Ragie webhook error:", error.message);
-    console.error("Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("Ragie verification failed:", reason);
-  });
-
-const recallWebhook = recall()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: recallReplayStore })
-  .event(participant_events_join, async (payload, context) => {
-    await logRecallParticipantEvent(payload, context);
-  })
-  .event(participant_events_leave, logRecallParticipantEvent)
-  .event(participant_events_update, logRecallParticipantEvent)
-  .event(participant_events_speech_on, logRecallParticipantEvent)
-  .event(participant_events_speech_off, logRecallParticipantEvent)
-  .event(participant_events_webcam_on, logRecallParticipantEvent)
-  .event(participant_events_webcam_off, logRecallParticipantEvent)
-  .event(participant_events_screenshare_on, logRecallParticipantEvent)
-  .event(participant_events_screenshare_off, logRecallParticipantEvent)
-  .event(participant_events_chat_message, async (payload, context) => {
-    console.log(
-      `Recall ${context.eventType}: ${payload.data.participant.name} -> ${payload.data.data.text}`,
-    );
-  })
-  .event(transcript_data, async (payload, context) => {
-    console.log(
-      `Recall ${context.eventType}: words=${payload.data.words.length}`,
-    );
-  })
-  .event(transcript_partial_data, async (payload, context) => {
-    console.log(
-      `Recall ${context.eventType}: words=${payload.data.words.length}`,
-    );
-  })
-  .event(bot_joining_call, logRecallBotCodeEvent)
-  .event(bot_in_waiting_room, logRecallBotCodeEvent)
-  .event(bot_in_call_not_recording, logRecallBotCodeEvent)
-  .event(bot_recording_permission_allowed, logRecallBotCodeEvent)
-  .event(bot_recording_permission_denied, logRecallBotCodeEvent)
-  .event(bot_in_call_recording, logRecallBotCodeEvent)
-  .event(bot_call_ended, logRecallBotCodeEvent)
-  .event(bot_done, logRecallBotCodeEvent)
-  .event(bot_fatal, logRecallBotCodeEvent)
-  .event(bot_breakout_room_entered, logRecallBotCodeEvent)
-  .event(bot_breakout_room_left, logRecallBotCodeEvent)
-  .event(bot_breakout_room_opened, logRecallBotCodeEvent)
-  .event(bot_breakout_room_closed, logRecallBotCodeEvent)
-  .onError(async (error, context) => {
-    console.error("Recall webhook error:", error.message);
-    console.error("Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("Recall verification failed:", reason);
-  });
-
-const stripeWebhook = stripe()
-  .instrument(otelInstrumentation)
-  .withReplayProtection({ store: stripeReplayStore })
-  .event(charge_failed, async (payload) => {
-    console.log("Stripe charge failed");
-    console.log(`Event ID: ${payload.id}`);
-    console.log(`Charge ID: ${payload.data.object.id}`);
-    console.log(`Failure: ${payload.data.object.failure_code}`);
-  })
-  .event(checkout_session_completed, async (payload) => {
-    console.log("Stripe checkout session completed");
-    console.log(`Event ID: ${payload.id}`);
-    console.log(`Session ID: ${payload.data.object.id}`);
-    console.log(`Payment status: ${payload.data.object.payment_status}`);
-  })
-  .event(payment_intent_succeeded, async (payload) => {
-    console.log("Stripe payment intent succeeded");
-    console.log(`Event ID: ${payload.id}`);
-    console.log(`PaymentIntent ID: ${payload.data.object.id}`);
-    console.log(`Latest charge: ${payload.data.object.latest_charge}`);
-  })
-  .onError(async (error, context) => {
-    console.error("Stripe webhook error:", error.message);
-    console.error("Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason) => {
-    console.error("Stripe verification failed:", reason);
-  });
-
-app.post(
-  "/webhooks/github",
-  toHonoNode(githubWebhook, {
-    secret: process.env.GITHUB_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`Successfully processed GitHub ${eventType} event`);
-    },
-  }),
-);
-
-app.post(
-  "/webhooks/ragie",
-  toHonoNode(ragieWebhook, {
-    secret: process.env.RAGIE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`Successfully processed Ragie ${eventType} event`);
-    },
-  }),
-);
-
-app.post(
-  "/webhooks/stripe",
-  toHonoNode(stripeWebhook, {
-    secret: process.env.STRIPE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`Successfully processed Stripe ${eventType} event`);
-    },
-  }),
-);
-
-app.post(
-  "/webhooks/recall",
-  toHonoNode(recallWebhook, {
-    secret: process.env.RECALL_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`Successfully processed Recall ${eventType} event`);
-    },
-  }),
-);
+app.post("/webhooks/github", githubHandler);
+app.post("/webhooks/ragie", ragieHandler);
+app.post("/webhooks/stripe", stripeHandler);
+app.post("/webhooks/recall", recallHandler);
 
 app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
@@ -263,25 +23,12 @@ serve(
     port,
   },
   (info) => {
-    console.log("Hono webhook server running");
-    console.log(`Server: http://localhost:${info.port}`);
-    console.log(
-      `GitHub endpoint: http://localhost:${info.port}/webhooks/github`,
-    );
-    console.log(
-      `Ragie endpoint:  http://localhost:${info.port}/webhooks/ragie`,
-    );
-    console.log(
-      `Stripe endpoint: http://localhost:${info.port}/webhooks/stripe`,
-    );
-    console.log(
-      `Recall endpoint: http://localhost:${info.port}/webhooks/recall`,
-    );
-    console.log(`Health check:    http://localhost:${info.port}/health`);
-    console.log("Environment variables:");
-    console.log("- GITHUB_WEBHOOK_SECRET");
-    console.log("- RAGIE_WEBHOOK_SECRET");
-    console.log("- STRIPE_WEBHOOK_SECRET");
-    console.log("- RECALL_WEBHOOK_SECRET");
+    console.log(`Hono example listening on http://localhost:${info.port}`);
+    console.log("Endpoints:");
+    console.log(`- POST http://localhost:${info.port}/webhooks/github`);
+    console.log(`- POST http://localhost:${info.port}/webhooks/ragie`);
+    console.log(`- POST http://localhost:${info.port}/webhooks/stripe`);
+    console.log(`- POST http://localhost:${info.port}/webhooks/recall`);
+    console.log(`- GET  http://localhost:${info.port}/health`);
   },
 );

--- a/apps/examples/hono-example/src/webhooks/github.ts
+++ b/apps/examples/hono-example/src/webhooks/github.ts
@@ -1,0 +1,45 @@
+import { github } from "@better-webhook/github";
+import { issues, pull_request, push } from "@better-webhook/github/events";
+import { toHonoNode } from "@better-webhook/hono";
+
+const githubWebhook = github()
+  .event(push, async (payload, context) => {
+    console.log("GitHub push received", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
+    });
+  })
+  .event(pull_request, async (payload, context) => {
+    console.log("GitHub pull request received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.pull_request.number,
+      title: payload.pull_request.title,
+    });
+  })
+  .event(issues, async (payload, context) => {
+    console.log("GitHub issue received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.issue.number,
+      title: payload.issue.title,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("GitHub webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("GitHub verification failed", { reason });
+  });
+
+export const githubHandler = toHonoNode(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", { eventType });
+  },
+});

--- a/apps/examples/hono-example/src/webhooks/ragie.ts
+++ b/apps/examples/hono-example/src/webhooks/ragie.ts
@@ -1,0 +1,46 @@
+import { toHonoNode } from "@better-webhook/hono";
+import { ragie } from "@better-webhook/ragie";
+import {
+  connection_sync_finished,
+  document_status_updated,
+  entity_extracted,
+} from "@better-webhook/ragie/events";
+
+const ragieWebhook = ragie()
+  .event(document_status_updated, async (payload) => {
+    console.log("Ragie document status updated", {
+      documentId: payload.document_id,
+      status: payload.status,
+      partition: payload.partition,
+    });
+  })
+  .event(connection_sync_finished, async (payload) => {
+    console.log("Ragie connection sync finished", {
+      connectionId: payload.connection_id,
+      syncId: payload.sync_id,
+      partition: payload.partition,
+    });
+  })
+  .event(entity_extracted, async (payload) => {
+    console.log("Ragie entity extracted", {
+      entityId: payload.entity_id,
+      documentId: payload.document_id,
+      instructionId: payload.instruction_id,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Ragie webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Ragie verification failed", { reason });
+  });
+
+export const ragieHandler = toHonoNode(ragieWebhook, {
+  secret: process.env.RAGIE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Ragie webhook processed", { eventType });
+  },
+});

--- a/apps/examples/hono-example/src/webhooks/recall.ts
+++ b/apps/examples/hono-example/src/webhooks/recall.ts
@@ -1,0 +1,66 @@
+import { toHonoNode } from "@better-webhook/hono";
+import { recall } from "@better-webhook/recall";
+import {
+  bot_done,
+  participant_events_chat_message,
+  participant_events_join,
+  transcript_data,
+} from "@better-webhook/recall/events";
+
+const recallWebhook = recall()
+  .event(participant_events_join, async (payload, context) => {
+    const participantEvent = payload.data;
+
+    console.log("Recall participant joined", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+    });
+  })
+  .event(participant_events_chat_message, async (payload, context) => {
+    const participantEvent = payload.data;
+    const message = participantEvent.data;
+
+    console.log("Recall chat message received", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+      text: message.text,
+      to: message.to,
+    });
+  })
+  .event(transcript_data, async (payload, context) => {
+    const transcript = payload.data;
+
+    console.log("Recall transcript segment received", {
+      eventType: context.eventType,
+      participantId: transcript.participant.id,
+      wordCount: transcript.words.length,
+    });
+  })
+  .event(bot_done, async (payload, context) => {
+    const botStatus = payload.data;
+
+    console.log("Recall bot finished", {
+      eventType: context.eventType,
+      botId: payload.bot.id,
+      code: botStatus.code,
+      subCode: botStatus.sub_code,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Recall webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Recall verification failed", { reason });
+  });
+
+export const recallHandler = toHonoNode(recallWebhook, {
+  secret: process.env.RECALL_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Recall webhook processed", { eventType });
+  },
+});

--- a/apps/examples/hono-example/src/webhooks/stripe.ts
+++ b/apps/examples/hono-example/src/webhooks/stripe.ts
@@ -1,0 +1,47 @@
+import { toHonoNode } from "@better-webhook/hono";
+import { stripe } from "@better-webhook/stripe";
+import {
+  charge_failed,
+  checkout_session_completed,
+  payment_intent_succeeded,
+} from "@better-webhook/stripe/events";
+
+const stripeWebhook = stripe()
+  .event(charge_failed, async (payload) => {
+    console.log("Stripe charge failed", {
+      eventId: payload.id,
+      chargeId: payload.data.object.id,
+      amount: payload.data.object.amount,
+      failureCode: payload.data.object.failure_code,
+    });
+  })
+  .event(checkout_session_completed, async (payload) => {
+    console.log("Stripe checkout completed", {
+      eventId: payload.id,
+      sessionId: payload.data.object.id,
+      paymentStatus: payload.data.object.payment_status,
+    });
+  })
+  .event(payment_intent_succeeded, async (payload) => {
+    console.log("Stripe payment intent succeeded", {
+      eventId: payload.id,
+      paymentIntentId: payload.data.object.id,
+      latestCharge: payload.data.object.latest_charge,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Stripe webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Stripe verification failed", { reason });
+  });
+
+export const stripeHandler = toHonoNode(stripeWebhook, {
+  secret: process.env.STRIPE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Stripe webhook processed", { eventType });
+  },
+});

--- a/apps/examples/nestjs-example/README.md
+++ b/apps/examples/nestjs-example/README.md
@@ -1,49 +1,72 @@
 # NestJS Example
 
-A simple NestJS app demonstrating `@better-webhook/github`,
-`@better-webhook/ragie`, `@better-webhook/recall`, and `@better-webhook/nestjs`.
+A NestJS app showing the default multi-provider setup for `@better-webhook/nestjs`.
+
+## Choose This Example If...
+
+- you want controller-based webhook routing in NestJS
+- you want raw-body verification with Nest's Express platform
+- you want GET endpoints that expose supported event metadata
+
+## What It Demonstrates
+
+- one NestJS handler module per provider under `src/webhooks`
+- controller routing for both webhook POST handlers and metadata GET endpoints
+- representative event handling for GitHub, Ragie, Stripe, and Recall
+
+Representative events in this app:
+
+- GitHub: `push`, `pull_request`, `issues`
+- Ragie: `document_status_updated`, `connection_sync_finished`, `entity_extracted`
+- Stripe: `charge.failed`, `checkout.session.completed`, `payment_intent.succeeded`
+- Recall: `participant_events.join`, `participant_events.chat_message`, `transcript.data`, `bot.done`
 
 ## Quick Start
 
 ```bash
-# From the repository root
 pnpm install
 pnpm --filter @better-webhook/nestjs-example dev
 ```
 
 Server URL: `http://localhost:3003`
 
+If you are running multiple examples at once, override `PORT`. `3003` is also used by `express-github-inmemory-replay-example`.
+
 ## Configuration
+
+Create your env vars before sending requests:
+
+```bash
+GITHUB_WEBHOOK_SECRET=your-github-secret
+RAGIE_WEBHOOK_SECRET=your-ragie-secret
+STRIPE_WEBHOOK_SECRET=your-stripe-secret
+RECALL_WEBHOOK_SECRET=your-recall-secret
+PORT=3003
+```
 
 | Variable                | Required | Description                             |
 | ----------------------- | -------- | --------------------------------------- |
 | `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
 | `RAGIE_WEBHOOK_SECRET`  | Yes      | Secret used to verify Ragie signatures  |
+| `STRIPE_WEBHOOK_SECRET` | Yes      | Secret used to verify Stripe signatures |
 | `RECALL_WEBHOOK_SECRET` | Yes      | Secret used to verify Recall signatures |
-
-Example:
-
-```bash
-GITHUB_WEBHOOK_SECRET=your-github-secret \
-RAGIE_WEBHOOK_SECRET=your-ragie-secret \
-RECALL_WEBHOOK_SECRET=your-recall-whsec-secret \
-pnpm --filter @better-webhook/nestjs-example dev
-```
+| `PORT`                  | No       | Override the default port (`3003`)      |
 
 ## Endpoints
 
-- `POST /webhooks/github` - GitHub webhook endpoint
-- `GET /webhooks/github` - GitHub endpoint info
-- `POST /webhooks/ragie` - Ragie webhook endpoint
-- `GET /webhooks/ragie` - Ragie endpoint info
-- `POST /webhooks/recall` - Recall.ai webhook endpoint
-- `GET /webhooks/recall` - Recall endpoint info
-- `GET /health` - Health check
+- `POST /webhooks/github` verifies and handles GitHub webhook events
+- `GET /webhooks/github` returns `{ status, endpoint, supportedEvents }` for the GitHub route
+- `POST /webhooks/ragie` verifies and handles Ragie webhook events
+- `GET /webhooks/ragie` returns `{ status, endpoint, supportedEvents }` for the Ragie route
+- `POST /webhooks/stripe` verifies and handles Stripe webhook events
+- `GET /webhooks/stripe` returns `{ status, endpoint, supportedEvents }` for the Stripe route
+- `POST /webhooks/recall` verifies and handles Recall webhook events
+- `GET /webhooks/recall` returns `{ status, endpoint, supportedEvents }` for the Recall route
+- `GET /health` returns `{ status, timestamp }` so you can confirm the app is up
 
-## Signed Testing
+## Try It
 
-Unsigned requests are rejected (`401`) because verification is required by
-default. Sign test payloads with the same secret configured in your env vars.
+Send a signed GitHub `push` event:
 
 ```bash
 SECRET="your-github-secret"
@@ -58,26 +81,36 @@ curl -X POST "http://localhost:3003/webhooks/github" \
   -d "$PAYLOAD"
 ```
 
-For dev-only unsigned testing, use a custom provider configured with
-`verification: "disabled"`. Do not use disabled verification in production.
+Expected result:
 
-## Replay Strategy Notes
+- the request succeeds with a verified response
+- the app logs `GitHub push received`
+- the app logs `GitHub webhook processed`
+- verified but unhandled events can return `204`
 
-This controller demonstrates replay protection strategies:
+## File Layout
 
-- GitHub uses the built-in replay store via `context.deliveryId`
-- Recall uses the built-in replay store via `webhook-id` / `svix-id`
-- Ragie uses `payload.nonce` from the signed envelope
+- `src/main.ts` boots Nest with `rawBody: true`
+- `src/webhooks.controller.ts` wires routes and metadata endpoints
+- `src/webhooks/github.webhook.ts` handles GitHub events and exports `githubInfo`
+- `src/webhooks/ragie.webhook.ts` handles Ragie events and exports `ragieInfo`
+- `src/webhooks/stripe.webhook.ts` handles Stripe events and exports `stripeInfo`
+- `src/webhooks/recall.webhook.ts` handles Recall events and exports `recallInfo`
 
-For production, use a shared replay store so duplicate detection works across
-multiple instances.
+## Recall Note
 
-For side-by-side examples of manual checks, `createInMemoryReplayStore`, and a
-custom `ReplayStore`, see `apps/examples/nextjs-example/app/api/webhooks`.
+The Recall example stays intentionally small and typed by inference. Handlers receive unwrapped `body.data`, but that payload still includes nested Recall-specific fields such as `payload.data.participant` and `payload.data.code`.
+
+## Advanced Topics
+
+This example keeps the default flow minimal. For replay protection and telemetry, use the canonical SDK docs:
+
+- `apps/docs/content/docs/sdk/providers.mdx`
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/opentelemetry.mdx`
 
 ## Troubleshooting
 
-- `401` responses: verify secrets match the sender and your local env vars.
-- Raw body support: keep `rawBody: true` in `main.ts`.
-- `204` responses: expected for verified but unhandled event types.
-- Replays after restart: expected with in-memory dedupe; switch to shared storage.
+- Keep `rawBody: true` enabled in `src/main.ts`.
+- `401` usually means the configured secret does not match the sender.
+- `204` is expected for verified but unhandled events.

--- a/apps/examples/nestjs-example/README.md
+++ b/apps/examples/nestjs-example/README.md
@@ -39,8 +39,8 @@ Create your env vars before sending requests:
 ```bash
 GITHUB_WEBHOOK_SECRET=your-github-secret
 RAGIE_WEBHOOK_SECRET=your-ragie-secret
-STRIPE_WEBHOOK_SECRET=your-stripe-secret
-RECALL_WEBHOOK_SECRET=your-recall-secret
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret
+RECALL_WEBHOOK_SECRET=whsec_your-recall-secret
 PORT=3003
 ```
 

--- a/apps/examples/nestjs-example/package.json
+++ b/apps/examples/nestjs-example/package.json
@@ -12,10 +12,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-webhook/core": "workspace:*",
     "@better-webhook/github": "workspace:*",
     "@better-webhook/nestjs": "workspace:*",
-    "@better-webhook/otel": "workspace:*",
     "@better-webhook/recall": "workspace:*",
     "@better-webhook/ragie": "workspace:*",
     "@nestjs/common": "^11.0.0",

--- a/apps/examples/nestjs-example/src/main.ts
+++ b/apps/examples/nestjs-example/src/main.ts
@@ -1,37 +1,25 @@
 import { NestFactory } from "@nestjs/core";
-import { AppModule } from "./app.module.js";
 import type { NestExpressApplication } from "@nestjs/platform-express";
+import { AppModule } from "./app.module.js";
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    // Enable raw body for webhook signature verification
     rawBody: true,
   });
 
-  const port = process.env.PORT || 3003;
+  const port = Number(process.env.PORT ?? "3003");
   await app.listen(port);
 
-  console.log(`
-🚀 NestJS webhook server running!
-   
-   Webhook endpoint: http://localhost:${port}/webhooks/github
-   Webhook endpoint: http://localhost:${port}/webhooks/ragie
-   Webhook endpoint: http://localhost:${port}/webhooks/stripe
-   Webhook endpoint: http://localhost:${port}/webhooks/recall
-   Health check:     http://localhost:${port}/health
-
-   To test with ngrok:
-   1. ngrok http ${port}
-   2. Configure webhook providers with the ngrok URL + /webhooks/[provider]
-   3. Set GITHUB_WEBHOOK_SECRET, RAGIE_WEBHOOK_SECRET, STRIPE_WEBHOOK_SECRET, and RECALL_WEBHOOK_SECRET
-
-   Or test locally with curl:
-   curl -X POST http://localhost:${port}/webhooks/github \\
-     -H "Content-Type: application/json" \\
-     -H "X-GitHub-Event: push" \\
-     -H "X-GitHub-Delivery: test-123" \\
-     -d '{"ref":"refs/heads/main","repository":{"id":1,"name":"test","full_name":"org/test","private":false},"commits":[{"id":"abc123","message":"Test commit","timestamp":"2024-01-01T00:00:00Z","url":"https://example.com","author":{"name":"Test","email":"test@example.com"},"committer":{"name":"Test","email":"test@example.com"}}],"head_commit":null,"before":"000","after":"abc","created":false,"deleted":false,"forced":false,"base_ref":null,"compare":"https://example.com","pusher":{"name":"test"},"sender":{"login":"test","id":1,"type":"User"}}'
-  `);
+  console.log(`NestJS example listening on http://localhost:${port}`);
+  console.log("Endpoints:");
+  console.log(`- POST http://localhost:${port}/webhooks/github`);
+  console.log(`- POST http://localhost:${port}/webhooks/ragie`);
+  console.log(`- POST http://localhost:${port}/webhooks/stripe`);
+  console.log(`- POST http://localhost:${port}/webhooks/recall`);
+  console.log(`- GET  http://localhost:${port}/health`);
+  console.log(
+    "Reminder: keep Nest raw body enabled for signature verification.",
+  );
 }
 
 bootstrap();

--- a/apps/examples/nestjs-example/src/main.ts
+++ b/apps/examples/nestjs-example/src/main.ts
@@ -7,7 +7,15 @@ async function bootstrap() {
     rawBody: true,
   });
 
-  const port = Number(process.env.PORT ?? "3003");
+  const portValue = process.env.PORT ?? "3003";
+  const port = Number(portValue);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new RangeError(
+      `PORT must be an integer between 1 and 65535. Received: ${portValue}`,
+    );
+  }
+
   await app.listen(port);
 
   console.log(`NestJS example listening on http://localhost:${port}`);

--- a/apps/examples/nestjs-example/src/webhooks.controller.ts
+++ b/apps/examples/nestjs-example/src/webhooks.controller.ts
@@ -1,289 +1,24 @@
-import { Controller, Post, Get, Req, Res } from "@nestjs/common";
-import type { Request, Response } from "express";
-import { github } from "@better-webhook/github";
-import { push, pull_request, issues } from "@better-webhook/github/events";
-import { recall } from "@better-webhook/recall";
-import {
-  bot_breakout_room_closed,
-  bot_breakout_room_entered,
-  bot_breakout_room_left,
-  bot_breakout_room_opened,
-  bot_call_ended,
-  bot_done,
-  bot_fatal,
-  bot_in_call_not_recording,
-  bot_in_call_recording,
-  bot_in_waiting_room,
-  bot_joining_call,
-  bot_recording_permission_allowed,
-  bot_recording_permission_denied,
-  participant_events_chat_message,
-  participant_events_join,
-  participant_events_leave,
-  participant_events_screenshare_off,
-  participant_events_screenshare_on,
-  participant_events_speech_off,
-  participant_events_speech_on,
-  participant_events_update,
-  participant_events_webcam_off,
-  participant_events_webcam_on,
-  transcript_data,
-  transcript_partial_data,
-} from "@better-webhook/recall/events";
-import { ragie } from "@better-webhook/ragie";
-import {
-  document_status_updated,
-  connection_sync_finished,
-  entity_extracted,
-} from "@better-webhook/ragie/events";
-import { stripe } from "@better-webhook/stripe";
-import {
-  charge_failed,
-  checkout_session_completed,
-  payment_intent_succeeded,
-} from "@better-webhook/stripe/events";
-import { toNestJS, type NestJSResult } from "@better-webhook/nestjs";
-import { createInMemoryReplayStore } from "@better-webhook/core";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
-
-// Extend Request type to include rawBody
-interface RawBodyRequest extends Request {
-  rawBody?: Buffer;
-}
-
-const githubReplayStore = createInMemoryReplayStore();
-const ragieReplayStore = createInMemoryReplayStore();
-const stripeReplayStore = createInMemoryReplayStore();
-const recallReplayStore = createInMemoryReplayStore();
-
-const otelInstrumentation = createOpenTelemetryInstrumentation({
-  includeEventTypeAttribute: true,
-});
-
-const logRecallParticipantEvent = async (
-  payload: { data: { participant: { name: string | null } } },
-  context: { eventType: string },
-) => {
-  console.log(
-    `Recall ${context.eventType}: ${payload.data.participant.name ?? "unknown participant"}`,
-  );
-};
-
-const logRecallBotCodeEvent = async (
-  payload: { data: { code: string } },
-  context: { eventType: string },
-) => {
-  console.log(`Recall ${context.eventType}: ${payload.data.code}`);
-};
+import { Controller, Get, Post, Req, Res } from "@nestjs/common";
+import type { Response } from "express";
+import { githubHandler, githubInfo } from "./webhooks/github.webhook.js";
+import { ragieHandler, ragieInfo } from "./webhooks/ragie.webhook.js";
+import { recallHandler, recallInfo } from "./webhooks/recall.webhook.js";
+import { stripeHandler, stripeInfo } from "./webhooks/stripe.webhook.js";
+import type { RawBodyRequest } from "./webhooks/types.js";
 
 @Controller()
 export class WebhooksController {
-  private writeResponse(res: Response, result: NestJSResult): void {
-    if (result.body !== undefined) {
-      res.status(result.statusCode).json(result.body);
-      return;
-    }
-
-    res.status(result.statusCode).end();
-  }
-
-  // Create a GitHub webhook handler with observability
-  private githubWebhook = github()
-    .instrument(otelInstrumentation)
-    .withReplayProtection({ store: githubReplayStore })
-    .event(push, async (payload, context) => {
-      console.log("📦 Push event received!");
-      console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-      console.log(`   Received at: ${context.receivedAt.toISOString()}`);
-      console.log(`   Repository: ${payload.repository.full_name}`);
-      console.log(`   Branch: ${payload.ref}`);
-      console.log(`   Commits: ${payload.commits.length}`);
-      payload.commits.forEach((commit) => {
-        console.log(`   - ${commit.message} (${commit.id.slice(0, 7)})`);
-      });
-    })
-    .event(pull_request, async (payload, context) => {
-      console.log("🔀 Pull request event received!");
-      console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-      console.log(`   Action: ${payload.action}`);
-      console.log(
-        `   PR #${payload.pull_request.number}: ${payload.pull_request.title}`,
-      );
-      console.log(`   State: ${payload.pull_request.state}`);
-    })
-    .event(issues, async (payload, context) => {
-      console.log("🎫 Issue event received!");
-      console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-      console.log(`   Action: ${payload.action}`);
-      console.log(`   Issue #${payload.issue.number}: ${payload.issue.title}`);
-      console.log(`   State: ${payload.issue.state}`);
-    })
-    .onError(async (error, context) => {
-      console.error("❌ Webhook error:", error.message);
-      console.error("   Event type:", context.eventType);
-    })
-    .onVerificationFailed(async (reason) => {
-      console.error("🔐 Verification failed:", reason);
-    });
-
-  // Create a Ragie webhook handler with observability
-  private ragieWebhook = ragie()
-    .instrument(otelInstrumentation)
-    .withReplayProtection({ store: ragieReplayStore })
-    .event(document_status_updated, async (payload) => {
-      console.log("📄 Document status updated!");
-      console.log(`   Document ID: ${payload.document_id}`);
-      console.log(`   Status: ${payload.status}`);
-      console.log(`   Partition: ${payload.partition}`);
-    })
-    .event(connection_sync_finished, async (payload) => {
-      console.log("✅ Connection sync finished!");
-      console.log(`   Connection ID: ${payload.connection_id}`);
-      console.log(`   Sync ID: ${payload.sync_id}`);
-      console.log(`   Partition: ${payload.partition}`);
-    })
-    .event(entity_extracted, async (payload) => {
-      console.log("🔍 Entity extraction completed!");
-      console.log(`   Document ID: ${payload.document_id}`);
-      console.log(`   Partition: ${payload.partition}`);
-    })
-    .onError(async (error, context) => {
-      console.error("❌ Ragie webhook error:", error.message);
-      console.error("   Event type:", context.eventType);
-    })
-    .onVerificationFailed(async (reason) => {
-      console.error("🔐 Ragie verification failed:", reason);
-    });
-
-  private recallWebhook = recall()
-    .instrument(otelInstrumentation)
-    .withReplayProtection({ store: recallReplayStore })
-    .event(participant_events_join, async (payload, context) => {
-      await logRecallParticipantEvent(payload, context);
-    })
-    .event(participant_events_leave, logRecallParticipantEvent)
-    .event(participant_events_update, logRecallParticipantEvent)
-    .event(participant_events_speech_on, logRecallParticipantEvent)
-    .event(participant_events_speech_off, logRecallParticipantEvent)
-    .event(participant_events_webcam_on, logRecallParticipantEvent)
-    .event(participant_events_webcam_off, logRecallParticipantEvent)
-    .event(participant_events_screenshare_on, logRecallParticipantEvent)
-    .event(participant_events_screenshare_off, logRecallParticipantEvent)
-    .event(participant_events_chat_message, async (payload, context) => {
-      console.log(
-        `Recall ${context.eventType}: ${payload.data.participant.name} -> ${payload.data.data.text}`,
-      );
-    })
-    .event(transcript_data, async (payload, context) => {
-      console.log(
-        `Recall ${context.eventType}: words=${payload.data.words.length}`,
-      );
-    })
-    .event(transcript_partial_data, async (payload, context) => {
-      console.log(
-        `Recall ${context.eventType}: words=${payload.data.words.length}`,
-      );
-    })
-    .event(bot_joining_call, logRecallBotCodeEvent)
-    .event(bot_in_waiting_room, logRecallBotCodeEvent)
-    .event(bot_in_call_not_recording, logRecallBotCodeEvent)
-    .event(bot_recording_permission_allowed, logRecallBotCodeEvent)
-    .event(bot_recording_permission_denied, logRecallBotCodeEvent)
-    .event(bot_in_call_recording, logRecallBotCodeEvent)
-    .event(bot_call_ended, logRecallBotCodeEvent)
-    .event(bot_done, logRecallBotCodeEvent)
-    .event(bot_fatal, logRecallBotCodeEvent)
-    .event(bot_breakout_room_entered, logRecallBotCodeEvent)
-    .event(bot_breakout_room_left, logRecallBotCodeEvent)
-    .event(bot_breakout_room_opened, logRecallBotCodeEvent)
-    .event(bot_breakout_room_closed, logRecallBotCodeEvent)
-    .onError(async (error, context) => {
-      console.error("❌ Recall webhook error:", error.message);
-      console.error("   Event type:", context.eventType);
-    })
-    .onVerificationFailed(async (reason) => {
-      console.error("🔐 Recall verification failed:", reason);
-    });
-
-  private stripeWebhook = stripe()
-    .instrument(otelInstrumentation)
-    .withReplayProtection({ store: stripeReplayStore })
-    .event(charge_failed, async (payload) => {
-      console.log("💳 Stripe charge failed");
-      console.log(`   Event ID: ${payload.id}`);
-      console.log(`   Charge ID: ${payload.data.object.id}`);
-      console.log(`   Amount: ${payload.data.object.amount}`);
-      console.log(`   Failure: ${payload.data.object.failure_code}`);
-    })
-    .event(checkout_session_completed, async (payload) => {
-      console.log("🧾 Stripe checkout session completed");
-      console.log(`   Event ID: ${payload.id}`);
-      console.log(`   Session ID: ${payload.data.object.id}`);
-      console.log(`   Payment status: ${payload.data.object.payment_status}`);
-    })
-    .event(payment_intent_succeeded, async (payload) => {
-      console.log("✅ Stripe payment intent succeeded");
-      console.log(`   Event ID: ${payload.id}`);
-      console.log(`   PaymentIntent ID: ${payload.data.object.id}`);
-      console.log(`   Latest charge: ${payload.data.object.latest_charge}`);
-    })
-    .onError(async (error, context) => {
-      console.error("❌ Stripe webhook error:", error.message);
-      console.error("   Event type:", context.eventType);
-    })
-    .onVerificationFailed(async (reason) => {
-      console.error("🔐 Stripe verification failed:", reason);
-    });
-
-  // Create the handlers with options
-  private githubHandler = toNestJS(this.githubWebhook, {
-    secret: process.env.GITHUB_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed GitHub ${eventType} event`);
-    },
-  });
-
-  private ragieHandler = toNestJS(this.ragieWebhook, {
-    secret: process.env.RAGIE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Ragie ${eventType} event`);
-    },
-  });
-
-  private recallHandler = toNestJS(this.recallWebhook, {
-    secret: process.env.RECALL_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Recall ${eventType} event`);
-    },
-  });
-
-  private stripeHandler = toNestJS(this.stripeWebhook, {
-    secret: process.env.STRIPE_WEBHOOK_SECRET,
-    onSuccess: (eventType) => {
-      console.log(`✅ Successfully processed Stripe ${eventType} event`);
-    },
-  });
-
   @Post("webhooks/github")
   async handleGitHubWebhook(
     @Req() req: RawBodyRequest,
     @Res() res: Response,
   ): Promise<void> {
-    const result = await this.githubHandler({
-      headers: req.headers as Record<string, string | string[] | undefined>,
-      body: req.body,
-      rawBody: req.rawBody,
-    });
-    this.writeResponse(res, result);
+    await githubHandler(req, res);
   }
 
   @Get("webhooks/github")
   getGitHubWebhookInfo(): object {
-    return {
-      status: "ok",
-      endpoint: "/webhooks/github",
-      supportedEvents: ["push", "pull_request", "issues"],
-    };
+    return githubInfo;
   }
 
   @Post("webhooks/ragie")
@@ -291,78 +26,12 @@ export class WebhooksController {
     @Req() req: RawBodyRequest,
     @Res() res: Response,
   ): Promise<void> {
-    const result = await this.ragieHandler({
-      headers: req.headers as Record<string, string | string[] | undefined>,
-      body: req.body,
-      rawBody: req.rawBody,
-    });
-    this.writeResponse(res, result);
+    await ragieHandler(req, res);
   }
 
   @Get("webhooks/ragie")
   getRagieWebhookInfo(): object {
-    return {
-      status: "ok",
-      endpoint: "/webhooks/ragie",
-      supportedEvents: [
-        "document_status_updated",
-        "document_deleted",
-        "entity_extracted",
-        "connection_sync_started",
-        "connection_sync_progress",
-        "connection_sync_finished",
-        "connection_limit_exceeded",
-        "partition_limit_exceeded",
-      ],
-    };
-  }
-
-  @Post("webhooks/recall")
-  async handleRecallWebhook(
-    @Req() req: RawBodyRequest,
-    @Res() res: Response,
-  ): Promise<void> {
-    const result = await this.recallHandler({
-      headers: req.headers as Record<string, string | string[] | undefined>,
-      body: req.body,
-      rawBody: req.rawBody,
-    });
-    this.writeResponse(res, result);
-  }
-
-  @Get("webhooks/recall")
-  getRecallWebhookInfo(): object {
-    return {
-      status: "ok",
-      endpoint: "/webhooks/recall",
-      supportedEvents: [
-        "participant_events.join",
-        "participant_events.leave",
-        "participant_events.update",
-        "participant_events.speech_on",
-        "participant_events.speech_off",
-        "participant_events.webcam_on",
-        "participant_events.webcam_off",
-        "participant_events.screenshare_on",
-        "participant_events.screenshare_off",
-        "participant_events.chat_message",
-        "transcript.data",
-        "transcript.partial_data",
-        "bot.joining_call",
-        "bot.in_waiting_room",
-        "bot.in_call_not_recording",
-        "bot.recording_permission_allowed",
-        "bot.recording_permission_denied",
-        "bot.in_call_recording",
-        "bot.call_ended",
-        "bot.done",
-        "bot.fatal",
-        "bot.breakout_room_entered",
-        "bot.breakout_room_left",
-        "bot.breakout_room_opened",
-        "bot.breakout_room_closed",
-      ],
-    };
+    return ragieInfo;
   }
 
   @Post("webhooks/stripe")
@@ -370,25 +39,25 @@ export class WebhooksController {
     @Req() req: RawBodyRequest,
     @Res() res: Response,
   ): Promise<void> {
-    const result = await this.stripeHandler({
-      headers: req.headers as Record<string, string | string[] | undefined>,
-      body: req.body,
-      rawBody: req.rawBody,
-    });
-    this.writeResponse(res, result);
+    await stripeHandler(req, res);
   }
 
   @Get("webhooks/stripe")
   getStripeWebhookInfo(): object {
-    return {
-      status: "ok",
-      endpoint: "/webhooks/stripe",
-      supportedEvents: [
-        "charge.failed",
-        "checkout.session.completed",
-        "payment_intent.succeeded",
-      ],
-    };
+    return stripeInfo;
+  }
+
+  @Post("webhooks/recall")
+  async handleRecallWebhook(
+    @Req() req: RawBodyRequest,
+    @Res() res: Response,
+  ): Promise<void> {
+    await recallHandler(req, res);
+  }
+
+  @Get("webhooks/recall")
+  getRecallWebhookInfo(): object {
+    return recallInfo;
   }
 
   @Get("health")

--- a/apps/examples/nestjs-example/src/webhooks/github.webhook.ts
+++ b/apps/examples/nestjs-example/src/webhooks/github.webhook.ts
@@ -1,0 +1,62 @@
+import type { Response } from "express";
+import { github } from "@better-webhook/github";
+import { issues, pull_request, push } from "@better-webhook/github/events";
+import { toNestJS } from "@better-webhook/nestjs";
+import type { RawBodyRequest } from "./types.js";
+import { toNestRequest, writeNestResult } from "./types.js";
+
+const githubWebhook = github()
+  .event(push, async (payload, context) => {
+    console.log("GitHub push received", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
+    });
+  })
+  .event(pull_request, async (payload, context) => {
+    console.log("GitHub pull request received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.pull_request.number,
+      title: payload.pull_request.title,
+    });
+  })
+  .event(issues, async (payload, context) => {
+    console.log("GitHub issue received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.issue.number,
+      title: payload.issue.title,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("GitHub webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("GitHub verification failed", { reason });
+  });
+
+const handleGitHub = toNestJS(githubWebhook, {
+  secret: process.env.GITHUB_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("GitHub webhook processed", { eventType });
+  },
+});
+
+export const githubInfo = {
+  status: "ok",
+  endpoint: "/webhooks/github",
+  supportedEvents: ["push", "pull_request", "issues"],
+};
+
+export async function githubHandler(
+  req: RawBodyRequest,
+  res: Response,
+): Promise<void> {
+  const result = await handleGitHub(toNestRequest(req));
+  writeNestResult(res, result);
+}

--- a/apps/examples/nestjs-example/src/webhooks/ragie.webhook.ts
+++ b/apps/examples/nestjs-example/src/webhooks/ragie.webhook.ts
@@ -1,0 +1,67 @@
+import type { Response } from "express";
+import { toNestJS } from "@better-webhook/nestjs";
+import { ragie } from "@better-webhook/ragie";
+import {
+  connection_sync_finished,
+  document_status_updated,
+  entity_extracted,
+} from "@better-webhook/ragie/events";
+import type { RawBodyRequest } from "./types.js";
+import { toNestRequest, writeNestResult } from "./types.js";
+
+const ragieWebhook = ragie()
+  .event(document_status_updated, async (payload) => {
+    console.log("Ragie document status updated", {
+      documentId: payload.document_id,
+      status: payload.status,
+      partition: payload.partition,
+    });
+  })
+  .event(connection_sync_finished, async (payload) => {
+    console.log("Ragie connection sync finished", {
+      connectionId: payload.connection_id,
+      syncId: payload.sync_id,
+      partition: payload.partition,
+    });
+  })
+  .event(entity_extracted, async (payload) => {
+    console.log("Ragie entity extracted", {
+      entityId: payload.entity_id,
+      documentId: payload.document_id,
+      instructionId: payload.instruction_id,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Ragie webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Ragie verification failed", { reason });
+  });
+
+const handleRagie = toNestJS(ragieWebhook, {
+  secret: process.env.RAGIE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Ragie webhook processed", { eventType });
+  },
+});
+
+export const ragieInfo = {
+  status: "ok",
+  endpoint: "/webhooks/ragie",
+  supportedEvents: [
+    "document_status_updated",
+    "connection_sync_finished",
+    "entity_extracted",
+  ],
+};
+
+export async function ragieHandler(
+  req: RawBodyRequest,
+  res: Response,
+): Promise<void> {
+  const result = await handleRagie(toNestRequest(req));
+  writeNestResult(res, result);
+}

--- a/apps/examples/nestjs-example/src/webhooks/recall.webhook.ts
+++ b/apps/examples/nestjs-example/src/webhooks/recall.webhook.ts
@@ -1,0 +1,88 @@
+import type { Response } from "express";
+import { toNestJS } from "@better-webhook/nestjs";
+import { recall } from "@better-webhook/recall";
+import {
+  bot_done,
+  participant_events_chat_message,
+  participant_events_join,
+  transcript_data,
+} from "@better-webhook/recall/events";
+import type { RawBodyRequest } from "./types.js";
+import { toNestRequest, writeNestResult } from "./types.js";
+
+const recallWebhook = recall()
+  .event(participant_events_join, async (payload, context) => {
+    const participantEvent = payload.data;
+
+    console.log("Recall participant joined", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+    });
+  })
+  .event(participant_events_chat_message, async (payload, context) => {
+    const participantEvent = payload.data;
+    const message = participantEvent.data;
+
+    console.log("Recall chat message received", {
+      eventType: context.eventType,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+      text: message.text,
+      to: message.to,
+    });
+  })
+  .event(transcript_data, async (payload, context) => {
+    const transcript = payload.data;
+
+    console.log("Recall transcript segment received", {
+      eventType: context.eventType,
+      participantId: transcript.participant.id,
+      wordCount: transcript.words.length,
+    });
+  })
+  .event(bot_done, async (payload, context) => {
+    const botStatus = payload.data;
+
+    console.log("Recall bot finished", {
+      eventType: context.eventType,
+      botId: payload.bot.id,
+      code: botStatus.code,
+      subCode: botStatus.sub_code,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Recall webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Recall verification failed", { reason });
+  });
+
+const handleRecall = toNestJS(recallWebhook, {
+  secret: process.env.RECALL_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Recall webhook processed", { eventType });
+  },
+});
+
+export const recallInfo = {
+  status: "ok",
+  endpoint: "/webhooks/recall",
+  supportedEvents: [
+    "participant_events.join",
+    "participant_events.chat_message",
+    "transcript.data",
+    "bot.done",
+  ],
+};
+
+export async function recallHandler(
+  req: RawBodyRequest,
+  res: Response,
+): Promise<void> {
+  const result = await handleRecall(toNestRequest(req));
+  writeNestResult(res, result);
+}

--- a/apps/examples/nestjs-example/src/webhooks/stripe.webhook.ts
+++ b/apps/examples/nestjs-example/src/webhooks/stripe.webhook.ts
@@ -1,0 +1,68 @@
+import type { Response } from "express";
+import { toNestJS } from "@better-webhook/nestjs";
+import { stripe } from "@better-webhook/stripe";
+import {
+  charge_failed,
+  checkout_session_completed,
+  payment_intent_succeeded,
+} from "@better-webhook/stripe/events";
+import type { RawBodyRequest } from "./types.js";
+import { toNestRequest, writeNestResult } from "./types.js";
+
+const stripeWebhook = stripe()
+  .event(charge_failed, async (payload) => {
+    console.log("Stripe charge failed", {
+      eventId: payload.id,
+      chargeId: payload.data.object.id,
+      amount: payload.data.object.amount,
+      failureCode: payload.data.object.failure_code,
+    });
+  })
+  .event(checkout_session_completed, async (payload) => {
+    console.log("Stripe checkout completed", {
+      eventId: payload.id,
+      sessionId: payload.data.object.id,
+      paymentStatus: payload.data.object.payment_status,
+    });
+  })
+  .event(payment_intent_succeeded, async (payload) => {
+    console.log("Stripe payment intent succeeded", {
+      eventId: payload.id,
+      paymentIntentId: payload.data.object.id,
+      latestCharge: payload.data.object.latest_charge,
+    });
+  })
+  .onError(async (error, context) => {
+    console.error("Stripe webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Stripe verification failed", { reason });
+  });
+
+const handleStripe = toNestJS(stripeWebhook, {
+  secret: process.env.STRIPE_WEBHOOK_SECRET,
+  onSuccess: (eventType) => {
+    console.log("Stripe webhook processed", { eventType });
+  },
+});
+
+export const stripeInfo = {
+  status: "ok",
+  endpoint: "/webhooks/stripe",
+  supportedEvents: [
+    "charge.failed",
+    "checkout.session.completed",
+    "payment_intent.succeeded",
+  ],
+};
+
+export async function stripeHandler(
+  req: RawBodyRequest,
+  res: Response,
+): Promise<void> {
+  const result = await handleStripe(toNestRequest(req));
+  writeNestResult(res, result);
+}

--- a/apps/examples/nestjs-example/src/webhooks/types.ts
+++ b/apps/examples/nestjs-example/src/webhooks/types.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from "express";
+import type { NestJSResult } from "@better-webhook/nestjs";
+
+export interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+export function writeNestResult(res: Response, result: NestJSResult): void {
+  if (result.body !== undefined) {
+    res.status(result.statusCode).json(result.body);
+    return;
+  }
+
+  res.status(result.statusCode).end();
+}
+
+export function toNestRequest(req: RawBodyRequest) {
+  return {
+    headers: req.headers as Record<string, string | string[] | undefined>,
+    body: req.body,
+    rawBody: req.rawBody,
+  };
+}

--- a/apps/examples/nextjs-example/README.md
+++ b/apps/examples/nextjs-example/README.md
@@ -40,8 +40,8 @@ Create your env vars before sending requests:
 ```bash
 GITHUB_WEBHOOK_SECRET=your-github-secret
 RAGIE_WEBHOOK_SECRET=your-ragie-secret
-STRIPE_WEBHOOK_SECRET=your-stripe-secret
-RECALL_WEBHOOK_SECRET=your-recall-secret
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret
+RECALL_WEBHOOK_SECRET=whsec_your-recall-secret
 RESEND_WEBHOOK_SECRET=whsec_your-resend-secret-base64
 ```
 

--- a/apps/examples/nextjs-example/README.md
+++ b/apps/examples/nextjs-example/README.md
@@ -1,68 +1,76 @@
 # Next.js Example
 
-A simple Next.js app demonstrating `@better-webhook/github`,
-`@better-webhook/stripe`, `@better-webhook/ragie`,
-`@better-webhook/recall`, `@better-webhook/resend`, and
-`@better-webhook/nextjs`.
+A Next.js App Router example showing the default route-per-provider setup for `@better-webhook/nextjs`.
+
+## Choose This Example If...
+
+- you want one route file per provider in App Router
+- you want the clearest Next.js example in the repo
+- you want to compare GitHub, Ragie, Stripe, Recall, and Resend in one app
+
+## What It Demonstrates
+
+- one `app/api/webhooks/.../route.ts` file per provider
+- provider metadata via `GET` handlers on each route
+- representative event handling for GitHub, Ragie, Stripe, Recall, and Resend
+
+Representative events in this app:
+
+- GitHub: `push`, `pull_request`, `issues`
+- Ragie: `document_status_updated`, `connection_sync_finished`, `entity_extracted`
+- Stripe: `charge.failed`, `checkout.session.completed`, `payment_intent.succeeded`
+- Recall: `participant_events.join`, `participant_events.chat_message`, `transcript.data`, `bot.done`
+- Resend: `email.delivered`, `email.bounced`, `email.received`, `domain.updated`, `contact.created`
 
 ## Quick Start
 
 ```bash
-# From the repository root
 pnpm install
 pnpm --filter @better-webhook/nextjs-example dev
 ```
 
 Server URL: `http://localhost:3002`
 
+The `dev` script is fixed to `next dev -p 3002`. If you need a different port, run a custom Next.js command instead of the package script.
+
 ## Configuration
 
-| Variable                | Required | Description                                           |
-| ----------------------- | -------- | ----------------------------------------------------- |
-| `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures               |
-| `STRIPE_WEBHOOK_SECRET` | Yes      | Secret used to verify Stripe signatures               |
-| `RAGIE_WEBHOOK_SECRET`  | Yes      | Secret used to verify Ragie signatures                |
-| `RECALL_WEBHOOK_SECRET` | Yes      | Secret used to verify Recall signatures (`whsec_...`) |
-| `RESEND_WEBHOOK_SECRET` | Yes      | Secret used to verify Resend Svix signatures          |
-
-Example:
+Create your env vars before sending requests:
 
 ```bash
-GITHUB_WEBHOOK_SECRET=your-github-secret \
-STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret \
-RAGIE_WEBHOOK_SECRET=your-ragie-secret \
-RECALL_WEBHOOK_SECRET=whsec_your-recall-secret-base64 \
-RESEND_WEBHOOK_SECRET=whsec_your-resend-secret-base64 \
-pnpm --filter @better-webhook/nextjs-example dev
-```
-
-Or create a `.env.local` file:
-
-```env
 GITHUB_WEBHOOK_SECRET=your-github-secret
-STRIPE_WEBHOOK_SECRET=whsec_your-stripe-secret
 RAGIE_WEBHOOK_SECRET=your-ragie-secret
-RECALL_WEBHOOK_SECRET=whsec_your-recall-secret-base64
+STRIPE_WEBHOOK_SECRET=your-stripe-secret
+RECALL_WEBHOOK_SECRET=your-recall-secret
 RESEND_WEBHOOK_SECRET=whsec_your-resend-secret-base64
 ```
 
+| Variable                | Required | Description                             |
+| ----------------------- | -------- | --------------------------------------- |
+| `GITHUB_WEBHOOK_SECRET` | Yes      | Secret used to verify GitHub signatures |
+| `STRIPE_WEBHOOK_SECRET` | Yes      | Secret used to verify Stripe signatures |
+| `RAGIE_WEBHOOK_SECRET`  | Yes      | Secret used to verify Ragie signatures  |
+| `RECALL_WEBHOOK_SECRET` | Yes      | Secret used to verify Recall signatures |
+| `RESEND_WEBHOOK_SECRET` | Yes      | Secret used to verify Resend signatures |
+
 ## Endpoints
 
-- `POST /api/webhooks/github` - GitHub webhook endpoint
-- `GET /api/webhooks/github` - GitHub endpoint info
-- `POST /api/webhooks/ragie` - Ragie webhook endpoint
-- `GET /api/webhooks/ragie` - Ragie endpoint info
-- `POST /api/webhooks/stripe` - Stripe webhook endpoint
-- `GET /api/webhooks/stripe` - Stripe endpoint info
-- `POST /api/webhooks/recall` - Recall.ai webhook endpoint
-- `GET /api/webhooks/recall` - Recall endpoint info
-- `POST /api/webhooks/resend` - Resend webhook endpoint
-- `GET /api/webhooks/resend` - Resend endpoint info
+- `POST /api/webhooks/github` verifies and handles GitHub webhook events
+- `GET /api/webhooks/github` returns `{ status, endpoint, supportedEvents }` for the GitHub route
+- `POST /api/webhooks/ragie` verifies and handles Ragie webhook events
+- `GET /api/webhooks/ragie` returns `{ status, endpoint, supportedEvents }` for the Ragie route
+- `POST /api/webhooks/stripe` verifies and handles Stripe webhook events
+- `GET /api/webhooks/stripe` returns `{ status, endpoint, supportedEvents }` for the Stripe route
+- `POST /api/webhooks/recall` verifies and handles Recall webhook events
+- `GET /api/webhooks/recall` returns `{ status, endpoint, supportedEvents }` for the Recall route
+- `POST /api/webhooks/resend` verifies and handles Resend webhook events
+- `GET /api/webhooks/resend` returns `{ status, endpoint, supportedEvents }` for the Resend route
 
-## Signed Testing
+There is no standalone `/health` route in this app. The `GET` route on each provider endpoint acts as the built-in status and metadata check.
 
-Unsigned requests are rejected (`401`) because verification is required by
-default. Sign test payloads with the same secret configured in your env vars.
+## Try It
+
+Send a signed GitHub `push` event:
 
 ```bash
 SECRET="your-github-secret"
@@ -77,7 +85,13 @@ curl -X POST "http://localhost:3002/api/webhooks/github" \
   -d "$PAYLOAD"
 ```
 
-For Resend, sign the Svix-style payload using the `whsec_...` secret:
+Expected result:
+
+- the request succeeds with a verified response
+- the app logs `GitHub push received`
+- the app logs `GitHub webhook processed`
+
+Send a signed Resend `email.delivered` event:
 
 ```bash
 SECRET="whsec_your-resend-secret-base64"
@@ -94,26 +108,39 @@ curl -X POST "http://localhost:3002/api/webhooks/resend" \
   -d "$PAYLOAD"
 ```
 
-For dev-only unsigned testing, use a custom provider configured with
-`verification: "disabled"`. Do not use disabled verification in production.
+Expected result:
 
-## Replay Strategy Notes
+- the request succeeds with a verified response
+- the app logs `Resend email delivered`
+- the app logs `Resend webhook processed`
 
-This example demonstrates several replay/idempotency strategies:
+## File Layout
 
-- Built-in replay store (`github` route) via `createInMemoryReplayStore()`
-- Built-in replay store (`stripe` route) via provider event ids
-- Built-in replay store (`resend` route) via `svix-id`
-- Custom replay store (`ragie` route) using provider replay metadata (`nonce`)
-- Built-in replay store (`recall` route) via `webhook-id` / `svix-id`
+- `app/api/webhooks/github/route.ts` handles GitHub events
+- `app/api/webhooks/ragie/route.ts` handles Ragie events
+- `app/api/webhooks/stripe/route.ts` handles Stripe events
+- `app/api/webhooks/recall/route.ts` handles Recall events
+- `app/api/webhooks/resend/route.ts` handles Resend events
 
-For production, use a shared persistent store (for example Redis) so replay
-state survives restarts and works across instances. Use atomic reservation
-semantics (`reserve/commit/release`) for custom stores.
+## Recall Note
+
+The Recall route shows the intended import story:
+
+- `recall` from `@better-webhook/recall`
+- event constants from `@better-webhook/recall/events`
+
+Handlers receive unwrapped `body.data`, but nested properties such as `payload.data.participant` still come from Recall's event payload schema.
+
+## Advanced Topics
+
+This app keeps the default routes minimal and easy to read. For replay protection and telemetry, use the canonical SDK docs:
+
+- `apps/docs/content/docs/sdk/providers.mdx`
+- `apps/docs/content/docs/sdk/replay-idempotency.mdx`
+- `apps/docs/content/docs/sdk/opentelemetry.mdx`
 
 ## Troubleshooting
 
-- `401` responses: verify secrets match the sender and your local env vars.
-- Signature mismatch: sign the exact raw payload bytes sent in `curl`.
-- `200`/`204` responses: verified requests may be acknowledged even when no handler is registered, depending on provider contract.
-- Duplicate events: check replay strategy and storage persistence.
+- `401` usually means the configured secret does not match the sender.
+- Sign the exact raw payload bytes you send.
+- `200` or `204` can both be valid for verified requests depending on provider behavior.

--- a/apps/examples/nextjs-example/app/api/webhooks/github/route.ts
+++ b/apps/examples/nextjs-example/app/api/webhooks/github/route.ts
@@ -1,67 +1,49 @@
 import { github } from "@better-webhook/github";
-import { push, pull_request, issues } from "@better-webhook/github/events";
+import { issues, pull_request, push } from "@better-webhook/github/events";
 import { toNextJS } from "@better-webhook/nextjs";
-import { createInMemoryReplayStore } from "@better-webhook/core";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
-
-// Core replay protection with built-in in-memory store
-const replayStore = createInMemoryReplayStore();
 
 const webhook = github()
-  .instrument(
-    createOpenTelemetryInstrumentation({
-      includeEventTypeAttribute: true,
-    }),
-  )
-  .withReplayProtection({
-    store: replayStore,
-  })
   .event(push, async (payload, context) => {
-    console.log("📦 Push event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Received at: ${context.receivedAt.toISOString()}`);
-    console.log(`   Repository: ${payload.repository.full_name}`);
-    console.log(`   Branch: ${payload.ref}`);
-    console.log(`   Commits: ${payload.commits.length}`);
-    payload.commits.forEach((commit) => {
-      console.log(`   - ${commit.message} (${commit.id.slice(0, 7)})`);
+    console.log("GitHub push received", {
+      deliveryId: context.deliveryId,
+      repository: payload.repository.full_name,
+      branch: payload.ref,
+      commits: payload.commits.length,
     });
   })
   .event(pull_request, async (payload, context) => {
-    console.log("🔀 Pull request event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Action: ${payload.action}`);
-    console.log(
-      `   PR #${payload.pull_request.number}: ${payload.pull_request.title}`,
-    );
-    console.log(`   State: ${payload.pull_request.state}`);
+    console.log("GitHub pull request received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.pull_request.number,
+      title: payload.pull_request.title,
+    });
   })
   .event(issues, async (payload, context) => {
-    console.log("🎫 Issue event received!");
-    console.log(`   Delivery ID: ${context.headers["x-github-delivery"]}`);
-    console.log(`   Action: ${payload.action}`);
-    console.log(`   Issue #${payload.issue.number}: ${payload.issue.title}`);
-    console.log(`   State: ${payload.issue.state}`);
+    console.log("GitHub issue received", {
+      deliveryId: context.deliveryId,
+      action: payload.action,
+      number: payload.issue.number,
+      title: payload.issue.title,
+    });
   })
   .onError(async (error, context) => {
-    console.error("❌ Webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
+    console.error("GitHub webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
   })
-  .onVerificationFailed(async (reason, headers) => {
-    console.error("🔐 Verification failed:", reason);
-    console.log("Headers: ", headers);
-    console.log("Received signature header: ", headers["x-hub-signature-256"]);
+  .onVerificationFailed(async (reason) => {
+    console.error("GitHub verification failed", { reason });
   });
 
-// Export the POST handler
 export const POST = toNextJS(webhook, {
   secret: process.env.GITHUB_WEBHOOK_SECRET,
   onSuccess: (eventType) => {
-    console.log(`✅ Successfully processed ${eventType} event`);
+    console.log("GitHub webhook processed", { eventType });
   },
 });
 
-// Optionally handle other methods
 export async function GET() {
   return new Response(
     JSON.stringify({

--- a/apps/examples/nextjs-example/app/api/webhooks/ragie/route.ts
+++ b/apps/examples/nextjs-example/app/api/webhooks/ragie/route.ts
@@ -1,150 +1,50 @@
+import { toNextJS } from "@better-webhook/nextjs";
 import { ragie } from "@better-webhook/ragie";
 import {
-  document_status_updated,
-  document_deleted,
-  entity_extracted,
-  connection_sync_started,
-  connection_sync_progress,
   connection_sync_finished,
-  connection_limit_exceeded,
-  partition_limit_exceeded,
+  document_status_updated,
+  entity_extracted,
 } from "@better-webhook/ragie/events";
-import { toNextJS } from "@better-webhook/nextjs";
-import type { ReplayContext, ReplayStore } from "@better-webhook/core";
 
-class ExampleReplayStore implements ReplayStore {
-  private readonly entries = new Map<string, number>();
-  private readonly cleanupIntervalMs = 60_000;
-  private readonly cleanupBatchSize = 128;
-  private lastCleanupAt = 0;
-
-  reserve(key: string, inFlightTtlSeconds: number): "reserved" | "duplicate" {
-    this.cleanupExpiredEntries();
-    const now = Date.now();
-    const expiresAt = this.entries.get(key);
-    if (expiresAt === undefined || expiresAt <= now) {
-      this.entries.set(key, now + inFlightTtlSeconds * 1000);
-      return "reserved";
-    }
-    return "duplicate";
-  }
-
-  commit(key: string, ttlSeconds: number): void {
-    this.cleanupExpiredEntries();
-    this.entries.set(key, Date.now() + ttlSeconds * 1000);
-  }
-
-  release(key: string): void {
-    this.entries.delete(key);
-  }
-
-  private cleanupExpiredEntries(): void {
-    const now = Date.now();
-    if (now - this.lastCleanupAt < this.cleanupIntervalMs) {
-      return;
-    }
-
-    let removed = 0;
-    for (const [entryKey, expiresAt] of this.entries) {
-      if (expiresAt <= now) {
-        this.entries.delete(entryKey);
-        removed++;
-      }
-      if (removed >= this.cleanupBatchSize) {
-        break;
-      }
-    }
-    this.lastCleanupAt = now;
-  }
-}
-
-// Custom replay store strategy example
-// This in-memory Map is process-local and ephemeral: it resets on cold starts
-// and is not shared across instances. Use a shared store (Redis/DynamoDB/etc.)
-// for production-grade replay protection.
-const customReplayStore: ReplayStore = new ExampleReplayStore();
 const webhook = ragie()
-  .withReplayProtection({
-    store: customReplayStore,
-    policy: {
-      ttlSeconds: 60 * 60,
-      key: (context: ReplayContext): string | undefined =>
-        context.replayKey ? `ragie:${context.replayKey}` : undefined,
-      onDuplicate: "conflict",
-    },
-  })
-  .event(document_status_updated, async (payload, context) => {
-    console.log("📄 Document status updated!");
-    console.log(`   Received at: ${context.receivedAt.toISOString()}`);
-    console.log(`   Document ID: ${payload.document_id}`);
-    console.log(`   Status: ${payload.status}`);
-    console.log(`   Partition: ${payload.partition || "default"}`);
-  })
-  .event(connection_sync_started, async (payload) => {
-    console.log("🚀 Connection sync started!");
-    console.log(`   Connection ID: ${payload.connection_id}`);
-    console.log(`   Sync ID: ${payload.sync_id}`);
-    console.log(`   Partition: ${payload.partition}`);
-  })
-  .event(connection_sync_progress, async (payload) => {
-    console.log("⏳ Connection sync progress!");
-    console.log(`   Connection ID: ${payload.connection_id}`);
-    console.log(`   Sync ID: ${payload.sync_id}`);
-    console.log(`   Creates: ${payload.created_count}/${payload.create_count}`);
-    console.log(
-      `   Content updates: ${payload.updated_content_count}/${payload.update_content_count}`,
-    );
-    console.log(
-      `   Metadata updates: ${payload.updated_metadata_count}/${payload.update_metadata_count}`,
-    );
-    console.log(`   Deletes: ${payload.deleted_count}/${payload.delete_count}`);
-    console.log(`   Errors: ${payload.errored_count}`);
+  .event(document_status_updated, async (payload) => {
+    console.log("Ragie document status updated", {
+      documentId: payload.document_id,
+      status: payload.status,
+      partition: payload.partition,
+    });
   })
   .event(connection_sync_finished, async (payload) => {
-    console.log("✅ Connection sync finished!");
-    console.log(`   Connection ID: ${payload.connection_id}`);
-    console.log(`   Sync ID: ${payload.sync_id}`);
-    console.log(`   Partition: ${payload.partition}`);
+    console.log("Ragie connection sync finished", {
+      connectionId: payload.connection_id,
+      syncId: payload.sync_id,
+      partition: payload.partition,
+    });
   })
   .event(entity_extracted, async (payload) => {
-    console.log("🔍 Entity extraction completed!");
-    console.log(`   Document ID: ${payload.document_id}`);
-    console.log(`   Partition: ${payload.partition || "default"}`);
-  })
-  .event(document_deleted, async (payload) => {
-    console.log("🗑️ Document deleted!");
-    console.log(`   Document ID: ${payload.document_id}`);
-    console.log(`   Partition: ${payload.partition}`);
-  })
-  .event(connection_limit_exceeded, async (payload) => {
-    console.log("⚠️ Connection limit exceeded!");
-    console.log(`   Connection ID: ${payload.connection_id}`);
-    console.log(`   Partition: ${payload.partition}`);
-    console.log(`   Limit type: ${payload.limit_type}`);
-  })
-  .event(partition_limit_exceeded, async (payload) => {
-    console.log("⚠️ Partition limit exceeded!");
-    console.log(`   Partition: ${payload.partition}`);
+    console.log("Ragie entity extracted", {
+      entityId: payload.entity_id,
+      documentId: payload.document_id,
+      instructionId: payload.instruction_id,
+    });
   })
   .onError(async (error, context) => {
-    console.error("❌ Ragie webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
+    console.error("Ragie webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
   })
-  .onVerificationFailed(async (reason, headers) => {
-    console.error("🔐 Verification failed:", reason);
-    console.log("Headers: ", headers);
-    console.log("Received signature header: ", headers["x-signature"]);
+  .onVerificationFailed(async (reason) => {
+    console.error("Ragie verification failed", { reason });
   });
 
-// Export the POST handler
 export const POST = toNextJS(webhook, {
   secret: process.env.RAGIE_WEBHOOK_SECRET,
   onSuccess: (eventType) => {
-    console.log(`✅ Successfully processed Ragie ${eventType} event`);
+    console.log("Ragie webhook processed", { eventType });
   },
 });
 
-// Optionally handle other methods
 export async function GET() {
   return new Response(
     JSON.stringify({
@@ -152,13 +52,8 @@ export async function GET() {
       endpoint: "/api/webhooks/ragie",
       supportedEvents: [
         "document_status_updated",
-        "document_deleted",
-        "entity_extracted",
-        "connection_sync_started",
-        "connection_sync_progress",
         "connection_sync_finished",
-        "connection_limit_exceeded",
-        "partition_limit_exceeded",
+        "entity_extracted",
       ],
     }),
     {

--- a/apps/examples/nextjs-example/app/api/webhooks/recall/route.ts
+++ b/apps/examples/nextjs-example/app/api/webhooks/recall/route.ts
@@ -1,234 +1,67 @@
-import { createInMemoryReplayStore } from "@better-webhook/core";
 import { toNextJS } from "@better-webhook/nextjs";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
 import { recall } from "@better-webhook/recall";
 import {
-  participant_events_join,
-  participant_events_leave,
-  participant_events_update,
-  participant_events_speech_on,
-  participant_events_speech_off,
-  participant_events_webcam_on,
-  participant_events_webcam_off,
-  participant_events_screenshare_on,
-  participant_events_screenshare_off,
-  participant_events_chat_message,
-  transcript_data,
-  transcript_partial_data,
-  bot_joining_call,
-  bot_in_waiting_room,
-  bot_in_call_not_recording,
-  bot_recording_permission_allowed,
-  bot_recording_permission_denied,
-  bot_in_call_recording,
-  bot_call_ended,
   bot_done,
-  bot_fatal,
-  bot_breakout_room_entered,
-  bot_breakout_room_left,
-  bot_breakout_room_opened,
-  bot_breakout_room_closed,
+  participant_events_chat_message,
+  participant_events_join,
+  transcript_data,
 } from "@better-webhook/recall/events";
 
-const recallReplayStore = createInMemoryReplayStore();
-
 const webhook = recall()
-  .instrument(
-    createOpenTelemetryInstrumentation({
-      includeEventTypeAttribute: true,
-    }),
-  )
-  .withReplayProtection({ store: recallReplayStore })
   .event(participant_events_join, async (payload, context) => {
-    console.log("🟢 participant joined", {
+    const participantEvent = payload.data;
+
+    console.log("Recall participant joined", {
       eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      participantName: payload.data.participant.name,
-    });
-  })
-  .event(participant_events_leave, async (payload, context) => {
-    console.log("🔴 participant left", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      participantName: payload.data.participant.name,
-    });
-  })
-  .event(participant_events_update, async (payload, context) => {
-    console.log("📝 participant updated", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      participantName: payload.data.participant.name,
-    });
-  })
-  .event(participant_events_speech_on, async (payload, context) => {
-    console.log("🗣️ participant speech on", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-    });
-  })
-  .event(participant_events_speech_off, async (payload, context) => {
-    console.log("🔇 participant speech off", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-    });
-  })
-  .event(participant_events_webcam_on, async (payload, context) => {
-    console.log("📷 participant webcam on", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-    });
-  })
-  .event(participant_events_webcam_off, async (payload, context) => {
-    console.log("📷 participant webcam off", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-    });
-  })
-  .event(participant_events_screenshare_on, async (payload, context) => {
-    console.log("🖥️ participant screenshare on", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-    });
-  })
-  .event(participant_events_screenshare_off, async (payload, context) => {
-    console.log("🖥️ participant screenshare off", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
     });
   })
   .event(participant_events_chat_message, async (payload, context) => {
-    console.log("💬 participant chat message", {
+    const participantEvent = payload.data;
+    const message = participantEvent.data;
+
+    console.log("Recall chat message received", {
       eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      text: payload.data.data.text,
-      to: payload.data.data.to,
+      participantId: participantEvent.participant.id,
+      participantName: participantEvent.participant.name,
+      text: message.text,
+      to: message.to,
     });
   })
   .event(transcript_data, async (payload, context) => {
-    console.log("📜 transcript data", {
+    const transcript = payload.data;
+
+    console.log("Recall transcript segment received", {
       eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      words: payload.data.words.map((word) => word.text).join(" "),
-    });
-  })
-  .event(transcript_partial_data, async (payload, context) => {
-    console.log("🧩 transcript partial", {
-      eventType: context.eventType,
-      participantId: payload.data.participant.id,
-      wordCount: payload.data.words.length,
-    });
-  })
-  .event(bot_joining_call, async (payload, context) => {
-    console.log("🤖 bot joining call", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_in_waiting_room, async (payload, context) => {
-    console.log("🤖 bot in waiting room", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_in_call_not_recording, async (payload, context) => {
-    console.log("🤖 bot in call not recording", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_recording_permission_allowed, async (payload, context) => {
-    console.log("🤖 bot recording permission allowed", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_recording_permission_denied, async (payload, context) => {
-    console.log("🤖 bot recording permission denied", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_in_call_recording, async (payload, context) => {
-    console.log("🤖 bot in call recording", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_call_ended, async (payload, context) => {
-    console.log("🤖 bot call ended", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
+      participantId: transcript.participant.id,
+      wordCount: transcript.words.length,
     });
   })
   .event(bot_done, async (payload, context) => {
-    console.log("🤖 bot done", {
+    const botStatus = payload.data;
+
+    console.log("Recall bot finished", {
       eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_fatal, async (payload, context) => {
-    console.log("🤖 bot fatal", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_breakout_room_entered, async (payload, context) => {
-    console.log("🤖 bot breakout room entered", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_breakout_room_left, async (payload, context) => {
-    console.log("🤖 bot breakout room left", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_breakout_room_opened, async (payload, context) => {
-    console.log("🤖 bot breakout room opened", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
-    });
-  })
-  .event(bot_breakout_room_closed, async (payload, context) => {
-    console.log("🤖 bot breakout room closed", {
-      eventType: context.eventType,
-      code: payload.data.code,
-      subCode: payload.data.sub_code,
+      botId: payload.bot.id,
+      code: botStatus.code,
+      subCode: botStatus.sub_code,
     });
   })
   .onError(async (error, context) => {
-    console.error("❌ Recall webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
-  })
-  .onVerificationFailed(async (reason, headers) => {
-    console.error("🔐 Recall verification failed:", reason);
-    console.log("Verification header presence:", {
-      hasWebhookId: typeof headers["webhook-id"] === "string",
-      hasTimestamp: typeof headers["webhook-timestamp"] === "string",
-      hasSignature: typeof headers["webhook-signature"] === "string",
+    console.error("Recall webhook error", {
+      eventType: context.eventType,
+      message: error.message,
     });
-    console.log(
-      "Tip: avoid logging raw signature/header values in production environments.",
-    );
+  })
+  .onVerificationFailed(async (reason) => {
+    console.error("Recall verification failed", { reason });
   });
 
 export const POST = toNextJS(webhook, {
   secret: process.env.RECALL_WEBHOOK_SECRET,
   onSuccess: (eventType) => {
-    console.log(`✅ Successfully processed Recall ${eventType} event`);
+    console.log("Recall webhook processed", { eventType });
   },
 });
 
@@ -239,30 +72,9 @@ export async function GET() {
       endpoint: "/api/webhooks/recall",
       supportedEvents: [
         "participant_events.join",
-        "participant_events.leave",
-        "participant_events.update",
-        "participant_events.speech_on",
-        "participant_events.speech_off",
-        "participant_events.webcam_on",
-        "participant_events.webcam_off",
-        "participant_events.screenshare_on",
-        "participant_events.screenshare_off",
         "participant_events.chat_message",
         "transcript.data",
-        "transcript.partial_data",
-        "bot.joining_call",
-        "bot.in_waiting_room",
-        "bot.in_call_not_recording",
-        "bot.recording_permission_allowed",
-        "bot.recording_permission_denied",
-        "bot.in_call_recording",
-        "bot.call_ended",
         "bot.done",
-        "bot.fatal",
-        "bot.breakout_room_entered",
-        "bot.breakout_room_left",
-        "bot.breakout_room_opened",
-        "bot.breakout_room_closed",
       ],
     }),
     {

--- a/apps/examples/nextjs-example/app/api/webhooks/resend/route.ts
+++ b/apps/examples/nextjs-example/app/api/webhooks/resend/route.ts
@@ -1,6 +1,4 @@
-import { createInMemoryReplayStore } from "@better-webhook/core";
 import { toNextJS } from "@better-webhook/nextjs";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
 import { resend } from "@better-webhook/resend";
 import {
   contact_created,
@@ -9,8 +7,6 @@ import {
   email_delivered,
   email_received,
 } from "@better-webhook/resend/events";
-
-const replayStore = createInMemoryReplayStore();
 
 const supportedEvents = [
   "email.delivered",
@@ -29,30 +25,22 @@ function countTags(tags: Record<string, string> | undefined): number {
 }
 
 const webhook = resend()
-  .instrument(
-    createOpenTelemetryInstrumentation({
-      includeEventTypeAttribute: true,
-    }),
-  )
-  .withReplayProtection({
-    store: replayStore,
-  })
   .event(email_delivered, async (payload) => {
-    console.log("✅ email.delivered", {
+    console.log("Resend email delivered", {
       emailId: payload.data.email_id,
       recipientCount: payload.data.to.length,
       tagCount: countTags(payload.data.tags),
     });
   })
   .event(email_bounced, async (payload) => {
-    console.log("⚠️ email.bounced", {
+    console.log("Resend email bounced", {
       emailId: payload.data.email_id,
       bounceType: payload.data.bounce.type,
       bounceSubType: payload.data.bounce.subType,
     });
   })
   .event(email_received, async (payload) => {
-    console.log("📨 email.received", {
+    console.log("Resend email received", {
       emailId: payload.data.email_id,
       messageId: payload.data.message_id,
       attachments: payload.data.attachments?.length ?? 0,
@@ -62,14 +50,14 @@ const webhook = resend()
     );
   })
   .event(domain_updated, async (payload) => {
-    console.log("🌐 domain.updated", {
+    console.log("Resend domain updated", {
       domainId: payload.data.id,
       status: payload.data.status,
       recordCount: payload.data.records.length,
     });
   })
   .event(contact_created, async (payload) => {
-    console.log("👤 contact.created", {
+    console.log("Resend contact created", {
       contactId: payload.data.id,
       audienceId: payload.data.audience_id,
       segmentCount: payload.data.segment_ids.length,
@@ -77,17 +65,19 @@ const webhook = resend()
     });
   })
   .onError(async (error, context) => {
-    console.error("❌ Resend webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
+    console.error("Resend webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
   })
   .onVerificationFailed(async (reason) => {
-    console.error("🔐 Resend verification failed:", reason);
+    console.error("Resend verification failed", { reason });
   });
 
 export const POST = toNextJS(webhook, {
   secret: process.env.RESEND_WEBHOOK_SECRET,
   onSuccess: (eventType) => {
-    console.log(`✅ Successfully processed Resend ${eventType} event`);
+    console.log("Resend webhook processed", { eventType });
   },
 });
 

--- a/apps/examples/nextjs-example/app/api/webhooks/stripe/route.ts
+++ b/apps/examples/nextjs-example/app/api/webhooks/stripe/route.ts
@@ -1,6 +1,4 @@
-import { createInMemoryReplayStore } from "@better-webhook/core";
 import { toNextJS } from "@better-webhook/nextjs";
-import { createOpenTelemetryInstrumentation } from "@better-webhook/otel";
 import { stripe } from "@better-webhook/stripe";
 import {
   charge_failed,
@@ -8,47 +6,43 @@ import {
   payment_intent_succeeded,
 } from "@better-webhook/stripe/events";
 
-const replayStore = createInMemoryReplayStore();
-
 const webhook = stripe()
-  .instrument(
-    createOpenTelemetryInstrumentation({
-      includeEventTypeAttribute: true,
-    }),
-  )
-  .withReplayProtection({
-    store: replayStore,
-  })
   .event(charge_failed, async (payload) => {
-    console.log("💳 charge.failed");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   Amount: ${payload.data.object.amount}`);
-    console.log(`   Failure: ${payload.data.object.failure_code}`);
+    console.log("Stripe charge failed", {
+      eventId: payload.id,
+      chargeId: payload.data.object.id,
+      amount: payload.data.object.amount,
+      failureCode: payload.data.object.failure_code,
+    });
   })
   .event(checkout_session_completed, async (payload) => {
-    console.log("🧾 checkout.session.completed");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   Session: ${payload.data.object.id}`);
-    console.log(`   Payment status: ${payload.data.object.payment_status}`);
+    console.log("Stripe checkout completed", {
+      eventId: payload.id,
+      sessionId: payload.data.object.id,
+      paymentStatus: payload.data.object.payment_status,
+    });
   })
   .event(payment_intent_succeeded, async (payload) => {
-    console.log("✅ payment_intent.succeeded");
-    console.log(`   Event ID: ${payload.id}`);
-    console.log(`   PaymentIntent: ${payload.data.object.id}`);
-    console.log(`   Latest charge: ${payload.data.object.latest_charge}`);
+    console.log("Stripe payment intent succeeded", {
+      eventId: payload.id,
+      paymentIntentId: payload.data.object.id,
+      latestCharge: payload.data.object.latest_charge,
+    });
   })
   .onError(async (error, context) => {
-    console.error("❌ Stripe webhook error:", error.message);
-    console.error("   Event type:", context.eventType);
+    console.error("Stripe webhook error", {
+      eventType: context.eventType,
+      message: error.message,
+    });
   })
   .onVerificationFailed(async (reason) => {
-    console.error("🔐 Stripe verification failed:", reason);
+    console.error("Stripe verification failed", { reason });
   });
 
 export const POST = toNextJS(webhook, {
   secret: process.env.STRIPE_WEBHOOK_SECRET,
   onSuccess: (eventType) => {
-    console.log(`✅ Successfully processed Stripe ${eventType} event`);
+    console.log("Stripe webhook processed", { eventType });
   },
 });
 

--- a/apps/examples/nextjs-example/app/page.tsx
+++ b/apps/examples/nextjs-example/app/page.tsx
@@ -1,54 +1,70 @@
+const endpoints = [
+  ["GitHub", "/api/webhooks/github", ["push", "pull_request", "issues"]],
+  [
+    "Ragie",
+    "/api/webhooks/ragie",
+    ["document_status_updated", "connection_sync_finished", "entity_extracted"],
+  ],
+  [
+    "Stripe",
+    "/api/webhooks/stripe",
+    ["charge.failed", "checkout.session.completed", "payment_intent.succeeded"],
+  ],
+  [
+    "Recall",
+    "/api/webhooks/recall",
+    [
+      "participant_events.join",
+      "participant_events.chat_message",
+      "transcript.data",
+      "bot.done",
+    ],
+  ],
+  [
+    "Resend",
+    "/api/webhooks/resend",
+    [
+      "email.delivered",
+      "email.bounced",
+      "email.received",
+      "domain.updated",
+      "contact.created",
+    ],
+  ],
+] as const;
+
 export default function Home() {
   return (
     <main style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
-      <h1>Better Webhook - Next.js Example</h1>
+      <h1>Better Webhook Example Routes</h1>
       <p>
-        This example demonstrates how to use <code>@better-webhook/github</code>
-        , <code>@better-webhook/stripe</code>,{" "}
-        <code>@better-webhook/ragie</code>, <code>@better-webhook/recall</code>,
-        and <code>@better-webhook/resend</code> with{" "}
-        <code>@better-webhook/nextjs</code>.
+        This app keeps each provider in its own route file so you can see the
+        consumer-side integration shape clearly.
       </p>
 
-      <h2>Endpoints</h2>
+      <h2>Provider Routes</h2>
       <ul>
-        <li>
-          <code>POST /api/webhooks/github</code> - GitHub webhook endpoint
-        </li>
-        <li>
-          <code>GET /api/webhooks/github</code> - GitHub endpoint info
-        </li>
-        <li>
-          <code>POST /api/webhooks/ragie</code> - Ragie webhook endpoint
-        </li>
-        <li>
-          <code>GET /api/webhooks/ragie</code> - Ragie endpoint info
-        </li>
-        <li>
-          <code>POST /api/webhooks/stripe</code> - Stripe webhook endpoint
-        </li>
-        <li>
-          <code>GET /api/webhooks/stripe</code> - Stripe endpoint info
-        </li>
-        <li>
-          <code>POST /api/webhooks/recall</code> - Recall.ai webhook endpoint
-        </li>
-        <li>
-          <code>GET /api/webhooks/recall</code> - Recall endpoint info
-        </li>
-        <li>
-          <code>POST /api/webhooks/resend</code> - Resend webhook endpoint
-        </li>
-        <li>
-          <code>GET /api/webhooks/resend</code> - Resend endpoint info
-        </li>
+        {endpoints.map(([name, path, events]) => {
+          return (
+            <li key={path}>
+              <strong>{name}</strong>: <code>POST {path}</code> and{" "}
+              <code>GET {path}</code> with events {events.join(", ")}
+            </li>
+          );
+        })}
       </ul>
 
-      <h2>Signed Testing</h2>
+      <h2>Recall Shape</h2>
       <p>
-        Unsigned requests are rejected by default. Sign test payloads with the
-        same secret configured in your environment.
+        Recall sends <code>{"{ event, data }"}</code>. The SDK routes on
+        <code> body.event</code> and passes the unwrapped <code>body.data</code>
+        to your handler. That payload still contains nested Recall fields such
+        as
+        <code> payload.data.participant</code> and{" "}
+        <code>payload.data.code</code>.
       </p>
+
+      <h2>Signed GitHub Test</h2>
       <pre
         style={{
           background: "#f4f4f4",
@@ -61,11 +77,11 @@ export default function Home() {
 PAYLOAD='{"ref":"refs/heads/main","repository":{"id":1,"name":"test","full_name":"org/test","private":false},"commits":[{"id":"abc123","message":"Test commit","timestamp":"2024-01-01T00:00:00Z","url":"https://example.com","author":{"name":"Test","email":"test@example.com"},"committer":{"name":"Test","email":"test@example.com"}}],"head_commit":null,"before":"000","after":"abc","created":false,"deleted":false,"forced":false,"base_ref":null,"compare":"https://example.com","pusher":{"name":"test"},"sender":{"login":"test","id":1,"type":"User"}}'
 SIGNATURE=$(printf '%s' "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.* //')
 
-curl -X POST http://localhost:3002/api/webhooks/github \\
-  -H "Content-Type: application/json" \\
-  -H "X-GitHub-Event: push" \\
-  -H "X-GitHub-Delivery: test-123" \\
-  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \\
+curl -X POST http://localhost:3002/api/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: push" \
+  -H "X-GitHub-Delivery: test-123" \
+  -H "X-Hub-Signature-256: sha256=$SIGNATURE" \
   -d "$PAYLOAD"`}
       </pre>
     </main>

--- a/apps/examples/nextjs-example/package.json
+++ b/apps/examples/nextjs-example/package.json
@@ -12,10 +12,8 @@
     "check-types": "next typegen && tsc --noEmit"
   },
   "dependencies": {
-    "@better-webhook/core": "workspace:*",
     "@better-webhook/github": "workspace:*",
     "@better-webhook/nextjs": "workspace:*",
-    "@better-webhook/otel": "workspace:*",
     "@better-webhook/recall": "workspace:*",
     "@better-webhook/resend": "workspace:*",
     "@better-webhook/ragie": "workspace:*",

--- a/better-webhook-skill/REFERENCE.md
+++ b/better-webhook-skill/REFERENCE.md
@@ -312,35 +312,37 @@ import {
 
 **Factory:** `recall(options?: { secret?: string }): WebhookBuilder<"recall">`
 
-**Verification:** Svix-style HMAC-SHA256 via `webhook-id`, `webhook-timestamp`, `webhook-signature` headers. Secret must have `whsec_` prefix. Event type from body `event` field. Payload unwrapped from `{ event, data }`. 5-minute timestamp tolerance.
+**Verification:** Svix-style HMAC-SHA256 via `webhook-id`, `webhook-timestamp`, `webhook-signature` headers. Secret must have `whsec_` prefix. Event type from body `event` field. Handler payload is unwrapped from `{ event, data }`, so handlers receive `body.data`. 5-minute timestamp tolerance.
 
-| Event Export                         | Event Name                             | Payload Type                        |
-| ------------------------------------ | -------------------------------------- | ----------------------------------- |
-| `participant_events_join`            | `"participant_events.join"`            | `RecallParticipantEvent`            |
-| `participant_events_leave`           | `"participant_events.leave"`           | `RecallParticipantEvent`            |
-| `participant_events_update`          | `"participant_events.update"`          | `RecallParticipantEvent`            |
-| `participant_events_speech_on`       | `"participant_events.speech_on"`       | `RecallParticipantEvent`            |
-| `participant_events_speech_off`      | `"participant_events.speech_off"`      | `RecallParticipantEvent`            |
-| `participant_events_webcam_on`       | `"participant_events.webcam_on"`       | `RecallParticipantEvent`            |
-| `participant_events_webcam_off`      | `"participant_events.webcam_off"`      | `RecallParticipantEvent`            |
-| `participant_events_screenshare_on`  | `"participant_events.screenshare_on"`  | `RecallParticipantEvent`            |
-| `participant_events_screenshare_off` | `"participant_events.screenshare_off"` | `RecallParticipantEvent`            |
-| `participant_events_chat_message`    | `"participant_events.chat_message"`    | `RecallParticipantChatMessageEvent` |
-| `transcript_data`                    | `"transcript.data"`                    | `RecallTranscriptDataEvent`         |
-| `transcript_partial_data`            | `"transcript.partial_data"`            | `RecallTranscriptPartialDataEvent`  |
-| `bot_joining_call`                   | `"bot.joining_call"`                   | `RecallBotEvent`                    |
-| `bot_in_waiting_room`                | `"bot.in_waiting_room"`                | `RecallBotEvent`                    |
-| `bot_in_call_not_recording`          | `"bot.in_call_not_recording"`          | `RecallBotEvent`                    |
-| `bot_recording_permission_allowed`   | `"bot.recording_permission_allowed"`   | `RecallBotEvent`                    |
-| `bot_recording_permission_denied`    | `"bot.recording_permission_denied"`    | `RecallBotEvent`                    |
-| `bot_in_call_recording`              | `"bot.in_call_recording"`              | `RecallBotEvent`                    |
-| `bot_call_ended`                     | `"bot.call_ended"`                     | `RecallBotEvent`                    |
-| `bot_done`                           | `"bot.done"`                           | `RecallBotEvent`                    |
-| `bot_fatal`                          | `"bot.fatal"`                          | `RecallBotEvent`                    |
-| `bot_breakout_room_entered`          | `"bot.breakout_room_entered"`          | `RecallBotEvent`                    |
-| `bot_breakout_room_left`             | `"bot.breakout_room_left"`             | `RecallBotEvent`                    |
-| `bot_breakout_room_opened`           | `"bot.breakout_room_opened"`           | `RecallBotEvent`                    |
-| `bot_breakout_room_closed`           | `"bot.breakout_room_closed"`           | `RecallBotEvent`                    |
+**Handler payload note:** Recall examples often use fields like `payload.data.participant`, `payload.data.words`, or `payload.data.code`. That is expected: the SDK unwraps the outer request envelope, but the Recall event payload itself still contains nested `data` properties.
+
+| Event Export                         | Event Name                             | Handler Payload Type                         |
+| ------------------------------------ | -------------------------------------- | -------------------------------------------- |
+| `participant_events_join`            | `"participant_events.join"`            | `RecallParticipantEventsJoinEvent`           |
+| `participant_events_leave`           | `"participant_events.leave"`           | `RecallParticipantEventsLeaveEvent`          |
+| `participant_events_update`          | `"participant_events.update"`          | `RecallParticipantEventsUpdateEvent`         |
+| `participant_events_speech_on`       | `"participant_events.speech_on"`       | `RecallParticipantEventsSpeechOnEvent`       |
+| `participant_events_speech_off`      | `"participant_events.speech_off"`      | `RecallParticipantEventsSpeechOffEvent`      |
+| `participant_events_webcam_on`       | `"participant_events.webcam_on"`       | `RecallParticipantEventsWebcamOnEvent`       |
+| `participant_events_webcam_off`      | `"participant_events.webcam_off"`      | `RecallParticipantEventsWebcamOffEvent`      |
+| `participant_events_screenshare_on`  | `"participant_events.screenshare_on"`  | `RecallParticipantEventsScreenshareOnEvent`  |
+| `participant_events_screenshare_off` | `"participant_events.screenshare_off"` | `RecallParticipantEventsScreenshareOffEvent` |
+| `participant_events_chat_message`    | `"participant_events.chat_message"`    | `RecallParticipantEventsChatMessageEvent`    |
+| `transcript_data`                    | `"transcript.data"`                    | `RecallTranscriptDataEvent`                  |
+| `transcript_partial_data`            | `"transcript.partial_data"`            | `RecallTranscriptPartialDataEvent`           |
+| `bot_joining_call`                   | `"bot.joining_call"`                   | `RecallBotJoiningCallEvent`                  |
+| `bot_in_waiting_room`                | `"bot.in_waiting_room"`                | `RecallBotInWaitingRoomEvent`                |
+| `bot_in_call_not_recording`          | `"bot.in_call_not_recording"`          | `RecallBotInCallNotRecordingEvent`           |
+| `bot_recording_permission_allowed`   | `"bot.recording_permission_allowed"`   | `RecallBotRecordingPermissionAllowedEvent`   |
+| `bot_recording_permission_denied`    | `"bot.recording_permission_denied"`    | `RecallBotRecordingPermissionDeniedEvent`    |
+| `bot_in_call_recording`              | `"bot.in_call_recording"`              | `RecallBotInCallRecordingEvent`              |
+| `bot_call_ended`                     | `"bot.call_ended"`                     | `RecallBotCallEndedEvent`                    |
+| `bot_done`                           | `"bot.done"`                           | `RecallBotDoneEvent`                         |
+| `bot_fatal`                          | `"bot.fatal"`                          | `RecallBotFatalEvent`                        |
+| `bot_breakout_room_entered`          | `"bot.breakout_room_entered"`          | `RecallBotBreakoutRoomEnteredEvent`          |
+| `bot_breakout_room_left`             | `"bot.breakout_room_left"`             | `RecallBotBreakoutRoomLeftEvent`             |
+| `bot_breakout_room_opened`           | `"bot.breakout_room_opened"`           | `RecallBotBreakoutRoomOpenedEvent`           |
+| `bot_breakout_room_closed`           | `"bot.breakout_room_closed"`           | `RecallBotBreakoutRoomClosedEvent`           |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
       "qs@6.14.0": "6.14.1"
     },
     "onlyBuiltDependencies": [
-      "@nestjs/core"
+      "@nestjs/core",
+      "@prisma/client",
+      "@prisma/engines",
+      "prisma"
     ]
   },
   "packageManager": "pnpm@10.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   apps/docs:
     dependencies:
@@ -42,7 +42,7 @@ importers:
         version: 16.4.0(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.8)
       fumadocs-mdx:
         specifier: 14.2.2
-        version: 14.2.2(@types/react@19.2.7)(fumadocs-core@16.4.0(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.8))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
+        version: 14.2.2(@types/react@19.2.7)(fumadocs-core@16.4.0(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.8))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       fumadocs-ui:
         specifier: 16.4.0
         version: 16.4.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tailwindcss@4.1.18)(zod@4.1.8)
@@ -95,18 +95,12 @@ importers:
 
   apps/examples/express-example:
     dependencies:
-      '@better-webhook/core':
-        specifier: workspace:*
-        version: link:../../../packages/core
       '@better-webhook/express':
         specifier: workspace:*
         version: link:../../../packages/express
       '@better-webhook/github':
         specifier: workspace:*
         version: link:../../../packages/github
-      '@better-webhook/otel':
-        specifier: workspace:*
-        version: link:../../../packages/otel
       '@better-webhook/ragie':
         specifier: workspace:*
         version: link:../../../packages/ragie
@@ -116,21 +110,6 @@ importers:
       '@better-webhook/stripe':
         specifier: workspace:*
         version: link:../../../packages/stripe
-      '@opentelemetry/api':
-        specifier: ^1.9.0
-        version: 1.9.1
-      '@opentelemetry/exporter-metrics-otlp-http':
-        specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics':
-        specifier: ^2.1.0
-        version: 2.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-node':
-        specifier: ^0.203.0
-        version: 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base':
-        specifier: ^2.1.0
-        version: 2.6.1(@opentelemetry/api@1.9.1)
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -157,20 +136,149 @@ importers:
         specifier: ^5.6.3
         version: 5.9.2
 
-  apps/examples/hono-example:
+  apps/examples/express-github-inmemory-replay-example:
     dependencies:
       '@better-webhook/core':
         specifier: workspace:*
         version: link:../../../packages/core
+      '@better-webhook/express':
+        specifier: workspace:*
+        version: link:../../../packages/express
+      '@better-webhook/github':
+        specifier: workspace:*
+        version: link:../../../packages/github
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+    devDependencies:
+      '@better-webhook/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/eslint-config
+      '@better-webhook/typescript-config':
+        specifier: workspace:*
+        version: link:../../../packages/typescript-config
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.10.4
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.2(jiti@2.6.1)
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  apps/examples/express-github-otel-example:
+    dependencies:
+      '@better-webhook/express':
+        specifier: workspace:*
+        version: link:../../../packages/express
+      '@better-webhook/github':
+        specifier: workspace:*
+        version: link:../../../packages/github
+      '@better-webhook/otel':
+        specifier: workspace:*
+        version: link:../../../packages/otel
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/resources':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.214.0
+        version: 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.6.1
+        version: 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.40.0
+        version: 1.40.0
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+    devDependencies:
+      '@better-webhook/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/eslint-config
+      '@better-webhook/typescript-config':
+        specifier: workspace:*
+        version: link:../../../packages/typescript-config
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.10.4
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.2(jiti@2.6.1)
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  apps/examples/express-github-prisma-replay-example:
+    dependencies:
+      '@better-webhook/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@better-webhook/express':
+        specifier: workspace:*
+        version: link:../../../packages/express
+      '@better-webhook/github':
+        specifier: workspace:*
+        version: link:../../../packages/github
+      '@prisma/client':
+        specifier: ^6.19.3
+        version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+      prisma:
+        specifier: ^6.19.3
+        version: 6.19.3(typescript@5.9.3)
+    devDependencies:
+      '@better-webhook/eslint-config':
+        specifier: workspace:*
+        version: link:../../../packages/eslint-config
+      '@better-webhook/typescript-config':
+        specifier: workspace:*
+        version: link:../../../packages/typescript-config
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@types/node':
+        specifier: ^24.3.1
+        version: 24.10.4
+      eslint:
+        specifier: ^9.35.0
+        version: 9.39.2(jiti@2.6.1)
+      tsx:
+        specifier: ^4.20.5
+        version: 4.20.5
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  apps/examples/hono-example:
+    dependencies:
       '@better-webhook/github':
         specifier: workspace:*
         version: link:../../../packages/github
       '@better-webhook/hono':
         specifier: workspace:*
         version: link:../../../packages/hono
-      '@better-webhook/otel':
-        specifier: workspace:*
-        version: link:../../../packages/otel
       '@better-webhook/ragie':
         specifier: workspace:*
         version: link:../../../packages/ragie
@@ -208,18 +316,12 @@ importers:
 
   apps/examples/nestjs-example:
     dependencies:
-      '@better-webhook/core':
-        specifier: workspace:*
-        version: link:../../../packages/core
       '@better-webhook/github':
         specifier: workspace:*
         version: link:../../../packages/github
       '@better-webhook/nestjs':
         specifier: workspace:*
         version: link:../../../packages/nestjs
-      '@better-webhook/otel':
-        specifier: workspace:*
-        version: link:../../../packages/otel
       '@better-webhook/ragie':
         specifier: workspace:*
         version: link:../../../packages/ragie
@@ -269,18 +371,12 @@ importers:
 
   apps/examples/nextjs-example:
     dependencies:
-      '@better-webhook/core':
-        specifier: workspace:*
-        version: link:../../../packages/core
       '@better-webhook/github':
         specifier: workspace:*
         version: link:../../../packages/github
       '@better-webhook/nextjs':
         specifier: workspace:*
         version: link:../../../packages/nextjs
-      '@better-webhook/otel':
-        specifier: workspace:*
-        version: link:../../../packages/otel
       '@better-webhook/ragie':
         specifier: workspace:*
         version: link:../../../packages/ragie
@@ -347,13 +443,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/eslint-config:
     devDependencies:
@@ -408,13 +504,13 @@ importers:
         version: 4.21.2
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.1.8
@@ -442,13 +538,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.2.1
@@ -476,13 +572,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/hono:
     dependencies:
@@ -507,13 +603,13 @@ importers:
         version: 4.12.0
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.2.1
@@ -547,13 +643,13 @@ importers:
         version: 0.2.2
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.1.8
@@ -581,13 +677,13 @@ importers:
         version: 16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.1.8
@@ -615,13 +711,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       zod:
         specifier: ^4.0.0
         version: 4.1.8
@@ -649,13 +745,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/recall:
     dependencies:
@@ -683,13 +779,13 @@ importers:
         version: 3.3.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/resend:
     dependencies:
@@ -714,13 +810,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/stripe:
     dependencies:
@@ -745,13 +841,13 @@ importers:
         version: 9.39.2(jiti@2.6.1)
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)
+        version: 4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   packages/typescript-config: {}
 
@@ -1886,22 +1982,22 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opentelemetry/api-logs@0.203.0':
-    resolution: {integrity: sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==}
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
-  '@opentelemetry/context-async-hooks@2.0.1':
-    resolution: {integrity: sha512-XuY23lSI3d4PEqKA+7SLtAgwqIfc6E/E9eAQWLN1vlpC53ybO3o6jW4BsXo1xvz9lYyyWItfQDDLzezER01mCw==}
+  '@opentelemetry/configuration@0.214.0':
+    resolution: {integrity: sha512-Q+awuEwxhETwIAXuxHvIY5ZMEP0ZqvxLTi9kclrkyVJppEUXYL3Bhiw3jYrxdHYMh0Y0tVInQH9FEZ1aMinvLA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+      '@opentelemetry/api': ^1.9.0
 
-  '@opentelemetry/core@2.0.1':
-    resolution: {integrity: sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==}
+  '@opentelemetry/context-async-hooks@2.6.1':
+    resolution: {integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -1912,113 +2008,107 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.203.0':
-    resolution: {integrity: sha512-g/2Y2noc/l96zmM+g0LdeuyYKINyBwN6FJySoU15LHPLcMN/1a0wNk2SegwKcxrRdE7Xsm7fkIR5n6XFe3QpPw==}
+  '@opentelemetry/exporter-logs-otlp-grpc@0.214.0':
+    resolution: {integrity: sha512-SwmFRwO8mi6nndzbsjPgSFg7qy1WeNHRFD+s6uCsdiUDUt3+yzI2qiHE3/ub2f37+/CbeGcG+Ugc8Gwr6nu2Aw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-logs-otlp-http@0.203.0':
-    resolution: {integrity: sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw==}
+  '@opentelemetry/exporter-logs-otlp-http@0.214.0':
+    resolution: {integrity: sha512-9qv2Tl/Hq6qc5pJCbzFJnzA0uvlb9DgM70yGJPYf3bA5LlLkRCpcn81i4JbcIH4grlQIWY6A+W7YG0LLvS1BAw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.203.0':
-    resolution: {integrity: sha512-nl/7S91MXn5R1aIzoWtMKGvqxgJgepB/sH9qW0rZvZtabnsjbf8OQ1uSx3yogtvLr0GzwD596nQKz2fV7q2RBw==}
+  '@opentelemetry/exporter-logs-otlp-proto@0.214.0':
+    resolution: {integrity: sha512-IWAVvCO1TlpotRjFmhQFz9RSfQy5BsLtDRBtptSrXZRwfyRPpuql/RMe5zdmu0Gxl3ERDFwOzOqkf3bwy7Jzcw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.203.0':
-    resolution: {integrity: sha512-FCCj9nVZpumPQSEI57jRAA89hQQgONuoC35Lt+rayWY/mzCAc6BQT7RFyFaZKJ2B7IQ8kYjOCPsF/HGFWjdQkQ==}
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.214.0':
+    resolution: {integrity: sha512-0NGxWHVYHgbp51SEzmsP+Hdups81eRs229STcSWHo3WO0aqY6RpJ9csxfyEtFgaNrBDv6UfOh0je4ss/ROS6XA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-http@0.203.0':
-    resolution: {integrity: sha512-HFSW10y8lY6BTZecGNpV3GpoSy7eaO0Z6GATwZasnT4bEsILp8UJXNG5OmEsz4SdwCSYvyCbTJdNbZP3/8LGCQ==}
+  '@opentelemetry/exporter-metrics-otlp-http@0.214.0':
+    resolution: {integrity: sha512-Tx/59RmjBgkXJ3qnsD04rpDrVWL53LU/czpgLJh+Ab98nAroe91I7vZ3uGN9mxwPS0jsZEnmqmHygVwB2vRMlA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-metrics-otlp-proto@0.203.0':
-    resolution: {integrity: sha512-OZnhyd9npU7QbyuHXFEPVm3LnjZYifuKpT3kTnF84mXeEQ84pJJZgyLBpU4FSkSwUkt/zbMyNAI7y5+jYTWGIg==}
+  '@opentelemetry/exporter-metrics-otlp-proto@0.214.0':
+    resolution: {integrity: sha512-pJIcghFGhx3VSCgP5U+yZx+OMNj0t+ttnhC8IjL5Wza7vWIczctF6t3AGcVQffi2dEqX+ZHANoBwoPR8y6RMKA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-prometheus@0.203.0':
-    resolution: {integrity: sha512-2jLuNuw5m4sUj/SncDf/mFPabUxMZmmYetx5RKIMIQyPnl6G6ooFzfeE8aXNRf8YD1ZXNlCnRPcISxjveGJHNg==}
+  '@opentelemetry/exporter-prometheus@0.214.0':
+    resolution: {integrity: sha512-4TGYoZKebUWVuYkV6r5wS2dUF4zH7EbWFw/Uqz1ZM1tGHQeFT9wzHGXq3iSIXMUrwu5jRdxjfMaXrYejPu2kpQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-grpc@0.203.0':
-    resolution: {integrity: sha512-322coOTf81bm6cAA8+ML6A+m4r2xTCdmAZzGNTboPXRzhwPt4JEmovsFAs+grpdarObd68msOJ9FfH3jxM6wqA==}
+  '@opentelemetry/exporter-trace-otlp-grpc@0.214.0':
+    resolution: {integrity: sha512-FWRZ7AWoTryYhthralHkfXUuyO3l7cRsnr49WcDio1orl2a7KxT8aDZdwQtV1adzoUvZ9Gfo+IstElghCS4zfw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-http@0.203.0':
-    resolution: {integrity: sha512-ZDiaswNYo0yq/cy1bBLJFe691izEJ6IgNmkjm4C6kE9ub/OMQqDXORx2D2j8fzTBTxONyzusbaZlqtfmyqURPw==}
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0':
+    resolution: {integrity: sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.203.0':
-    resolution: {integrity: sha512-1xwNTJ86L0aJmWRwENCJlH4LULMG2sOXWIVw+Szta4fkqKVY50Eo4HoVKKq6U9QEytrWCr8+zjw0q/ZOeXpcAQ==}
+  '@opentelemetry/exporter-trace-otlp-proto@0.214.0':
+    resolution: {integrity: sha512-ON0spYWb2yAdQ9b+ItNyK0c6qdtcs+0eVR4YFJkhJL7agfT8sHFg0e5EesauSRiTHPZHiDobI92k77q0lwAmqg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-zipkin@2.0.1':
-    resolution: {integrity: sha512-a9eeyHIipfdxzCfc2XPrE+/TI3wmrZUDFtG2RRXHSbZZULAny7SyybSvaDvS77a7iib5MPiAvluwVvbGTsHxsw==}
+  '@opentelemetry/exporter-zipkin@2.6.1':
+    resolution: {integrity: sha512-km2/hD3inLTqtLnUAHDGz7ZP/VOyZNslrC/iN66x4jkmpckwlONW54LRPNI6fm09/musDtZga9EWsxgwnjGUlw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
 
-  '@opentelemetry/instrumentation@0.203.0':
-    resolution: {integrity: sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==}
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.203.0':
-    resolution: {integrity: sha512-Wbxf7k+87KyvxFr5D7uOiSq/vHXWommvdnNE7vECO3tAhsA2GfOlpWINCMWUEPdHZ7tCXxw6Epp3vgx3jU7llQ==}
+  '@opentelemetry/otlp-exporter-base@0.214.0':
+    resolution: {integrity: sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.203.0':
-    resolution: {integrity: sha512-te0Ze1ueJF+N/UOFl5jElJW4U0pZXQ8QklgSfJ2linHN0JJsuaHG8IabEUi2iqxY8ZBDlSiz1Trfv5JcjWWWwQ==}
+  '@opentelemetry/otlp-grpc-exporter-base@0.214.0':
+    resolution: {integrity: sha512-IDP6zcyA24RhNZ289MP6eToIZcinlmirHjX8v3zKCQ2ZhPpt5cGwkN91tCth337lqHIgWcTy90uKRiX/SzALDw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-transformer@0.203.0':
-    resolution: {integrity: sha512-Y8I6GgoCna0qDQ2W6GCRtaF24SnvqvA8OfeTi7fqigD23u8Jpb4R5KFv/pRvrlGagcCLICMIyh9wiejp4TXu/A==}
+  '@opentelemetry/otlp-transformer@0.214.0':
+    resolution: {integrity: sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/propagator-b3@2.0.1':
-    resolution: {integrity: sha512-Hc09CaQ8Tf5AGLmf449H726uRoBNGPBL4bjr7AnnUpzWMvhdn61F78z9qb6IqB737TffBsokGAK1XykFEZ1igw==}
+  '@opentelemetry/propagator-b3@2.6.1':
+    resolution: {integrity: sha512-Dvz9TA6cPqIbxolSzQ5x9br6iQlqdGhVYrm+oYc7pfJ7LaVXz8F0XIqhWbnKB5YvfZ6SUmabBUUxnvHs/9uhxA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/propagator-jaeger@2.0.1':
-    resolution: {integrity: sha512-7PMdPBmGVH2eQNb/AtSJizQNgeNTfh6jQFqys6lfhd6P4r+m/nTh3gKPPpaCXVdRQ+z93vfKk+4UGty390283w==}
+  '@opentelemetry/propagator-jaeger@2.6.1':
+    resolution: {integrity: sha512-kKFMxBcjBZAC1vBch5mtZ/dJQvcAEKWga+c+q5iGgRLPIE6Mc649zEwMaCIQCzalziMJQiyUadFYMHmELB7AFw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
-  '@opentelemetry/resources@2.0.1':
-    resolution: {integrity: sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/resources@2.6.1':
     resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
@@ -2026,17 +2116,11 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.203.0':
-    resolution: {integrity: sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw==}
+  '@opentelemetry/sdk-logs@0.214.0':
+    resolution: {integrity: sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.0.1':
-    resolution: {integrity: sha512-wf8OaJoSnujMAHWR3g+/hGvNcsC16rf9s1So4JlMiFaFHiE4HpIA3oUh+uWZQ7CNuK8gVW/pQSkgoa5HkkOl0g==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
   '@opentelemetry/sdk-metrics@2.6.1':
     resolution: {integrity: sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==}
@@ -2044,14 +2128,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
 
-  '@opentelemetry/sdk-node@0.203.0':
-    resolution: {integrity: sha512-zRMvrZGhGVMvAbbjiNQW3eKzW/073dlrSiAKPVWmkoQzah9wfynpVPeL55f9fVIm0GaBxTLcPeukWGy0/Wj7KQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.0.1':
-    resolution: {integrity: sha512-xYLlvk/xdScGx1aEqvxLwf6sXQLXCjk3/1SQT9X9AoN5rXRhkdvIFShuNNmtTEPRBqcsMbS4p/gJLNI2wXaDuQ==}
+  '@opentelemetry/sdk-node@0.214.0':
+    resolution: {integrity: sha512-gl2XvQBJuPjhGcw9SsnQO5qxChAPMuGRPFaD8lqtF+Cey91NgGUQ0sio2vlDFOSm3JOLzc44vL+OAfx1dXuZjg==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -2062,8 +2140,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/sdk-trace-node@2.0.1':
-    resolution: {integrity: sha512-UhdbPF19pMpBtCWYP5lHbTogLWx9N0EBxtdagvkn5YtsAnCBZzL7SjktG+ZmupRgifsHMjwUaCCaVmqGfSADmA==}
+  '@opentelemetry/sdk-trace-node@2.6.1':
+    resolution: {integrity: sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -2079,6 +2157,36 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@prisma/client@6.19.3':
+    resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.19.3':
+    resolution: {integrity: sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==}
+
+  '@prisma/debug@6.19.3':
+    resolution: {integrity: sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+
+  '@prisma/engines@6.19.3':
+    resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
+
+  '@prisma/fetch-engine@6.19.3':
+    resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
+
+  '@prisma/get-platform@6.19.3':
+    resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -3442,6 +3550,14 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -3510,8 +3626,14 @@ packages:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -3587,6 +3709,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -3705,6 +3830,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -3720,6 +3849,9 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -3727,6 +3859,9 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -3758,6 +3893,10 @@ packages:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -3768,6 +3907,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
@@ -3776,6 +3918,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -4061,11 +4207,18 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4311,6 +4464,10 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -4469,8 +4626,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-in-the-middle@1.15.0:
-    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -5242,6 +5400,9 @@ packages:
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -5252,6 +5413,11 @@ packages:
   npm-to-yarn@3.0.1:
     resolution: {integrity: sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  nypm@0.6.5:
+    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -5287,6 +5453,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -5411,6 +5580,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5436,6 +5608,9 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5489,6 +5664,16 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prisma@6.19.3:
+    resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -5510,6 +5695,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -5535,6 +5723,9 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -5680,9 +5871,9 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  require-in-the-middle@7.5.2:
-    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
-    engines: {node: '>=8.6.0'}
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6521,6 +6712,11 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -7711,180 +7907,176 @@ snapshots:
   '@open-draft/until@2.1.0':
     optional: true
 
-  '@opentelemetry/api-logs@0.203.0':
+  '@opentelemetry/api-logs@0.214.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/configuration@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      yaml: 2.8.3
 
-  '@opentelemetry/core@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/exporter-logs-otlp-grpc@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-grpc@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-http@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-logs-otlp-proto@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-logs-otlp-proto@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-metrics-otlp-grpc@0.203.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@grpc/grpc-js': 1.14.3
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-metrics-otlp-http@0.203.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-metrics-otlp-proto@0.203.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-prometheus@0.203.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/exporter-trace-otlp-grpc@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-grpc-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-trace-otlp-proto@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-metrics-otlp-proto@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/exporter-zipkin@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-prometheus@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/exporter-trace-otlp-grpc@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-exporter-base@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-grpc-exporter-base@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-grpc-exporter-base@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-exporter-base': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/otlp-transformer': 0.203.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-transformer@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/otlp-transformer@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
       protobufjs: 7.5.4
 
-  '@opentelemetry/propagator-b3@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/propagator-b3@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/propagator-jaeger@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/propagator-jaeger@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7892,18 +8084,13 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-logs@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-
-  '@opentelemetry/sdk-metrics@2.0.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7911,40 +8098,36 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-node@0.203.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-node@0.214.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/api-logs': 0.203.0
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-http': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-logs-otlp-proto': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-http': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-metrics-otlp-proto': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-prometheus': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-grpc': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-http': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-trace-otlp-proto': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/exporter-zipkin': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-b3': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-jaeger': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-logs': 0.203.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-node': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/configuration': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
     transitivePeerDependencies:
       - supports-color
-
-  '@opentelemetry/sdk-trace-base@2.0.1(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7953,12 +8136,12 @@ snapshots:
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-trace-node@2.0.1(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/context-async-hooks': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/core': 2.0.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/sdk-trace-base': 2.0.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
@@ -7966,6 +8149,41 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 6.19.3(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@6.19.3':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.21.0
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.19.3': {}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+
+  '@prisma/engines@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.3
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/fetch-engine@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/get-platform@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -8940,41 +9158,41 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))':
+  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.4(@types/node@24.10.4)(typescript@5.9.2)
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))':
+  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.4(@types/node@24.10.4)(typescript@5.9.3)
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))':
+  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.4(@types/node@24.3.1)(typescript@5.9.2)
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
-  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))':
+  '@vitest/mocker@4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.4(@types/node@24.3.1)(typescript@5.9.3)
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.0.16':
     dependencies:
@@ -9362,6 +9580,21 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.6.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -9418,7 +9651,13 @@ snapshots:
 
   ci-info@3.9.0: {}
 
-  cjs-module-lexer@1.4.3: {}
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -9491,6 +9730,8 @@ snapshots:
       typedarray: 0.0.6
 
   confbox@0.1.8: {}
+
+  confbox@0.2.4: {}
 
   consola@3.4.2: {}
 
@@ -9581,6 +9822,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge-ts@7.1.5: {}
+
   deepmerge@4.3.1: {}
 
   defaults@1.0.4:
@@ -9599,9 +9842,13 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.7: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   destroy@1.2.0: {}
 
@@ -9625,6 +9872,8 @@ snapshots:
 
   dotenv@16.0.3: {}
 
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -9635,11 +9884,18 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.267: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
 
   encodeurl@1.0.2: {}
 
@@ -10220,9 +10476,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  exsolve@1.0.8: {}
+
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -10410,7 +10672,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.2(@types/react@19.2.7)(fumadocs-core@16.4.0(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.8))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)):
+  fumadocs-mdx@14.2.2(@types/react@19.2.7)(fumadocs-core@16.4.0(@types/react@19.2.7)(lucide-react@0.561.0(react@19.2.3))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(zod@4.1.8))(next@16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -10434,7 +10696,7 @@ snapshots:
       '@types/react': 19.2.7
       next: 16.1.5(@babel/core@7.28.5)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10522,6 +10784,15 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.5
+      pathe: 2.0.3
 
   github-slugger@2.0.0: {}
 
@@ -10722,11 +10993,11 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@1.15.0:
+  import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
-      cjs-module-lexer: 1.4.3
+      cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
@@ -11812,6 +12083,8 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  node-fetch-native@1.6.7: {}
+
   node-releases@2.0.27: {}
 
   normalize-package-data@6.0.2:
@@ -11821,6 +12094,12 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   npm-to-yarn@3.0.1: {}
+
+  nypm@0.6.5:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.0.2
 
   object-assign@4.1.1: {}
 
@@ -11865,6 +12144,8 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obug@2.1.1: {}
+
+  ohash@2.0.11: {}
 
   on-finished@2.4.1:
     dependencies:
@@ -12004,6 +12285,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -12022,17 +12305,24 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.20.5
+      yaml: 2.8.3
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -12056,6 +12346,15 @@ snapshots:
   prettier@2.8.8: {}
 
   prettier@3.6.2: {}
+
+  prisma@6.19.3(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 6.19.3
+      '@prisma/engines': 6.19.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - magicast
 
   process@0.11.10: {}
 
@@ -12089,6 +12388,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@6.1.0: {}
+
   qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
@@ -12116,6 +12417,11 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       unpipe: 1.0.0
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:
@@ -12319,11 +12625,10 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2:
+  require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
       module-details-from-path: 1.0.4
-      resolve: 1.22.11
     transitivePeerDependencies:
       - supports-color
 
@@ -12919,7 +13224,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2):
+  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
@@ -12930,7 +13235,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.50.1
       source-map: 0.8.0-beta.0
@@ -12947,7 +13252,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3):
+  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.9)
       cac: 6.7.14
@@ -12958,7 +13263,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.50.1
       source-map: 0.8.0-beta.0
@@ -13226,7 +13531,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5):
+  vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13241,8 +13546,9 @@ snapshots:
       lightningcss: 1.30.2
       terser: 5.44.1
       tsx: 4.20.5
+      yaml: 2.8.3
 
-  vite@7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5):
+  vite@7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13257,11 +13563,12 @@ snapshots:
       lightningcss: 1.30.2
       terser: 5.44.1
       tsx: 4.20.5
+      yaml: 2.8.3
 
-  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5):
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
+      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -13278,7 +13585,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13296,10 +13603,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5):
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
+      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.10.4)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -13316,7 +13623,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13334,10 +13641,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5):
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
+      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.2))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -13354,7 +13661,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13372,10 +13679,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5):
+  vitest@4.0.16(@opentelemetry/api@1.9.1)(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5))
+      '@vitest/mocker': 4.0.16(msw@2.12.4(@types/node@24.3.1)(typescript@5.9.3))(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -13392,7 +13699,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)
+      vite: 7.3.0(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13540,6 +13847,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,8 @@
     "RAGIE_WEBHOOK_SECRET",
     "RECALL_WEBHOOK_SECRET",
     "RESEND_WEBHOOK_SECRET",
+    "DATABASE_URL",
+    "NODE_ENV",
     "PORT"
   ],
   "tasks": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four new focused example applications (in-memory replay, Prisma replay, OpenTelemetry, and enhanced multi-provider examples for Express/Hono/Next.js/NestJS) and expands the SDK documentation with comprehensive provider references and replay/OTel guides. The refactored webhook handlers follow a consistent pattern across all adapters.

- **P1** — `express-github-prisma-replay-example/src/index.ts`: `SIGINT`/`SIGTERM` handlers call `process.exit(0)` synchronously alongside `void shutdown()`, so `prisma.$disconnect()` never completes before the process exits. The OTel example in the same PR demonstrates the correct pattern (placing `process.exit` inside the `async` shutdown function after the `await`).

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the graceful-shutdown race condition in the Prisma replay example.

One P1 defect: the Prisma example's SIGINT/SIGTERM handlers exit the process before `prisma.$disconnect()` completes. All other changes are well-structured example code and documentation with no functional issues.

apps/examples/express-github-prisma-replay-example/src/index.ts — shutdown race condition.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Webhook secrets are consumed from environment variables and never hardcoded. Signature verification is delegated to the SDK on every handler. The `PrismaReplayStore` uses parameterised queries (`$executeRaw` with tagged template literals) so there is no SQL injection risk.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/examples/express-github-prisma-replay-example/src/index.ts | Shutdown handlers call `process.exit(0)` synchronously before `prisma.$disconnect()` completes; health endpoint lacks error handling for DB failures. |
| apps/examples/express-github-prisma-replay-example/src/replay-store.ts | PrismaReplayStore correctly implements atomic reservation via conditional `ON CONFLICT DO UPDATE WHERE`; release handles P2025 (not-found) gracefully. |
| apps/examples/express-github-otel-example/src/telemetry.ts | Uses deprecated `SEMRESATTRS_SERVICE_NAME`; otherwise telemetry setup is clean with proper start/stop lifecycle management. |
| apps/examples/express-github-otel-example/src/index.ts | Correctly patterns the graceful shutdown — `process.exit` lives inside the async `shutdown` function after `await stopTelemetry()`. |
| apps/examples/nestjs-example/src/webhooks/types.ts | Clean adapter shim: `toNestRequest` maps NestJS raw-body request to the SDK contract; `writeNestResult` handles body/no-body response paths. |
| apps/examples/nestjs-example/src/webhooks.controller.ts | Controller correctly delegates to per-provider handler functions; GET info endpoints added alongside each POST webhook route. |
| apps/examples/express-example/src/index.ts | Clean Express setup with `express.raw` per route; all four providers wired correctly with health endpoint. |
| apps/docs/content/docs/sdk/replay-idempotency.mdx | Accurate documentation of replay protection; Redis and Prisma examples are consistent with SDK contract. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Provider as Webhook Provider
    participant Adapter as Framework Adapter
    participant Builder as WebhookBuilder
    participant Verifier as Signature Verifier
    participant Replay as ReplayStore
    participant Handler as Event Handler

    Provider->>Adapter: POST /webhooks/{provider}
    Adapter->>Builder: process(request)
    Builder->>Verifier: verify(rawBody, headers, secret)
    alt Verification fails
        Verifier-->>Builder: false
        Builder-->>Adapter: 401
    else Verification passes
        Verifier-->>Builder: true
        Builder->>Replay: reserve(replayKey, inFlightTtl)
        alt Duplicate detected
            Replay-->>Builder: duplicate
            Builder-->>Adapter: 409
        else New event
            Replay-->>Builder: reserved
            Builder->>Handler: handler(payload, context)
            Handler-->>Builder: done
            Builder->>Replay: commit(replayKey, ttl)
            Builder-->>Adapter: 200
        end
    end
    Adapter-->>Provider: HTTP response
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/examples/express-github-prisma-replay-example/src/index.ts
Line: 27-34

Comment:
**`process.exit` called before `prisma.$disconnect` completes**

`process.exit(0)` is called synchronously right after `void shutdown()`, so the `await prisma.$disconnect()` inside `shutdown` never finishes before the process exits. This leaves database connections in an undefined state and can produce connection-pool warnings. The OTel example in this PR gets this right by placing `process.exit(0)` *inside* the async function after the `await`.

```suggestion
process.on("SIGINT", () => {
  void (async () => {
    await shutdown();
    process.exit(0);
  })();
});

process.on("SIGTERM", () => {
  void (async () => {
    await shutdown();
    process.exit(0);
  })();
});
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/examples/express-github-otel-example/src/telemetry.ts
Line: 11

Comment:
**Deprecated semantic-conventions attribute**

`SEMRESATTRS_SERVICE_NAME` was deprecated in `@opentelemetry/semantic-conventions` ≥ 1.21 in favour of `ATTR_SERVICE_NAME`. The old constant still works but will log deprecation notices in newer SDK versions.

```suggestion
import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
```

And update the usage:

```ts
resource: resourceFromAttributes({
  [ATTR_SERVICE_NAME]: "better-webhook-express-github-otel-example",
}),
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/examples/express-github-prisma-replay-example/src/index.ts
Line: 14-17

Comment:
**Health endpoint throws on DB failure**

If `prisma.$queryRaw` rejects (e.g. DB unreachable), the unhandled rejection propagates to Express with no error response. Wrap the query in a try/catch to return an explicit `503` instead:

```suggestion
app.get("/health", async (_req, res) => {
  try {
    await prisma.$queryRaw`SELECT 1`;
    res.json({ status: "ok", timestamp: new Date().toISOString() });
  } catch {
    res.status(503).json({ status: "error", timestamp: new Date().toISOString() });
  }
});
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add Express GitHub Prisma replay e..."](https://github.com/endalk200/better-webhook/commit/a18839abce71033ae7fc2d44ef948ca175320481) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27904490)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->