### PR TITLE
fix: handle Prisma replay release errors safely

### DIFF
--- a/apps/examples/express-github-prisma-replay-example/src/replay-store.ts
+++ b/apps/examples/express-github-prisma-replay-example/src/replay-store.ts
@@ -1,6 +1,16 @@
-import { Prisma } from "@prisma/client";
 import type { ReplayReserveResult, ReplayStore } from "@better-webhook/core";
 import { prisma } from "./prisma.js";
+
+function isPrismaRecordNotFoundError(
+  error: unknown,
+): error is { code: "P2025" } {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "P2025"
+  );
+}
 
 export class PrismaReplayStore implements ReplayStore {
   async reserve(
@@ -35,10 +45,7 @@ export class PrismaReplayStore implements ReplayStore {
     try {
       await prisma.replayRecord.delete({ where: { key } });
     } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === "P2025"
-      ) {
+      if (isPrismaRecordNotFoundError(error)) {
         return;
       }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `PrismaReplayStore.release` idempotent by catching Prisma's `P2025` ("record not found") error and returning silently, aligning it with the `InMemoryReplayStore` behaviour where deleting a missing key is a no-op. The logic is correct and the fix is well-scoped.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct and the only finding is a minor style suggestion.

No P0 or P1 issues; the single comment is a P2 style suggestion to use `instanceof Prisma.PrismaClientKnownRequestError` instead of duck-typing, which doesn't affect correctness in practice.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/examples/express-github-prisma-replay-example/src/replay-store.ts | Adds try-catch to `release` to silently handle Prisma P2025 "record not found" errors, making the method idempotent; error detection uses duck-typing instead of `instanceof Prisma.PrismaClientKnownRequestError`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["release(key)"] --> B["prisma.replayRecord.delete(where: key)"]
    B -->|Success| C["return void"]
    B -->|Throws| D{isPrismaRecordNotFoundError?}
    D -->|Yes – P2025| E["return void (no-op)"]
    D -->|No – other error| F["re-throw error"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/examples/express-github-prisma-replay-example/src/replay-store.ts
Line: 4-13

Comment:
**Prefer `instanceof` over duck-typing for Prisma errors**

The guard checks for a `code` property with duck-typing, which would silently swallow any error that happens to carry `code: "P2025"` — not just Prisma errors. Since `@prisma/client` is already a dependency, using `Prisma.PrismaClientKnownRequestError` is more precise and self-documenting.

```suggestion
import { Prisma } from "@prisma/client";

function isPrismaRecordNotFoundError(
  error: unknown,
): error is Prisma.PrismaClientKnownRequestError {
  return (
    error instanceof Prisma.PrismaClientKnownRequestError &&
    error.code === "P2025"
  );
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: handle Prisma replay release errors..."](https://github.com/endalk200/better-webhook/commit/b90604e10819dd4a17ec925820fde2e317ed1b88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27986890)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->