### PR TITLE
feat(cli): add structured version command

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -11,7 +11,7 @@ Workflow:
 5. If a PR changes publishable packages but should not create a release, run `pnpm changeset --empty` and commit that file instead.
 6. Do not manually edit published package versions or package changelogs in feature PRs. Release automation generates those from the `.changeset/*.md` files.
 7. When ready to release run one of:
-   - `pnpm release:version` then open a PR (if using PR flow).
+   - `pnpm run changeset:version` then open a PR (if using PR flow).
    - `pnpm release` locally to version + build + publish in one go.
 8. Publish only after verifying build output.
 

--- a/docs/how-tos/release-sdks-and-cli.md
+++ b/docs/how-tos/release-sdks-and-cli.md
@@ -250,7 +250,7 @@ Also verify the GitHub Release exists for the pushed tag and contains:
 
 As of 2026-04-26:
 
-- `@better-webhook/cli@beta` is `2.0.0-beta.2`.
+- `@better-webhook/cli@beta` is `2.0.0-beta.2`; this branch prepares `2.0.0-beta.3`.
 - `@better-webhook/cli@latest` is `3.10.1`, an older package shape with the `better-webhook` bin.
 - `@better-webhook/cli@dev` is `0.0.0-dev`; it is not part of the current Go CLI release flow.
 - The new Go CLI wrapper exposes the `bw` bin.

--- a/docs/how-tos/release-sdks-and-cli.md
+++ b/docs/how-tos/release-sdks-and-cli.md
@@ -1,0 +1,280 @@
+# How To Release SDKs and CLI
+
+This runbook covers the two release paths in this repo:
+
+- SDK packages: Changesets release PR, then publish from `main`.
+- CLI: annotated `cli/v*` tag, then publish GitHub Release artifacts and npm packages.
+
+Run every local command through Devbox.
+
+## Release SDK Packages
+
+Use this flow for `@better-webhook/core`, adapters, providers, and `@better-webhook/otel`.
+
+### 1. Prepare the Change
+
+Add or update the SDK code and tests. If the change affects public SDK behavior or published APIs, review docs under `apps/docs/content`.
+
+Add a changeset:
+
+```bash
+devbox run -- pnpm changeset
+```
+
+Select every affected public SDK package and choose the semver bump. Use an empty changeset only when the PR touches release-watched files but should not publish an SDK package:
+
+```bash
+devbox run -- pnpm changeset --empty
+```
+
+Do not manually edit SDK package versions or SDK changelogs in the feature PR. Changesets generates those in the release PR.
+
+### 2. Verify Locally
+
+Run the full release-quality check set:
+
+```bash
+devbox run -- pnpm run format:check
+devbox run -- pnpm run lint
+devbox run -- pnpm run check-types
+devbox run -- pnpm run test
+devbox run -- pnpm run build
+```
+
+The SDK release workflow itself runs lint, type check, test, and build after the Trivy gate. It does not run `format:check`, so run formatting checks before merging.
+
+If formatting fails, apply it and rerun the checks:
+
+```bash
+devbox run -- pnpm run format:write
+```
+
+For a narrow package check, use:
+
+```bash
+devbox run -- pnpm --filter @better-webhook/core run build
+devbox run -- pnpm --filter @better-webhook/core run check-types
+devbox run -- pnpm --filter @better-webhook/core run lint
+devbox run -- pnpm --filter @better-webhook/core run test
+```
+
+Replace `@better-webhook/core` with the package being released.
+
+### 3. Merge the Feature PR
+
+Merge the feature PR to `main` with its changeset file.
+
+The `Release SDK Packages` workflow runs on `main`. If unpublished changesets exist, Changesets opens or updates a release PR named `chore: release packages`.
+
+### 4. Review the Release PR
+
+Review the release PR for:
+
+- Correct package version bumps.
+- Correct changelog entries.
+- Correct workspace dependency updates.
+- Docs changes when SDK behavior changed.
+- Passing CI and release workflow checks.
+
+The actual local command behind the versioning step is:
+
+```bash
+devbox run -- pnpm run changeset:version
+```
+
+You usually do not need to run it manually because the GitHub workflow handles the release PR.
+
+### 5. Publish
+
+Merge the release PR to `main`.
+
+The next `Release SDK Packages` workflow run publishes packages with:
+
+```bash
+devbox run -- pnpm release:publish
+```
+
+through `changesets/action`.
+
+After publish, verify npm:
+
+```bash
+devbox run -- npm view @better-webhook/core version dist-tags --json
+devbox run -- npm view @better-webhook/express version dist-tags --json
+devbox run -- npm view @better-webhook/github version dist-tags --json
+```
+
+Check every package included in the release, not only these examples.
+
+## Release the CLI
+
+Use this flow for `@better-webhook/cli` and its native platform packages. The CLI is not released by Changesets.
+
+### 1. Choose the Version
+
+Edit both version locations so they match:
+
+- `packages/cli/package.json`
+- `packages/cli/internal/cli/version.go`
+
+Use beta prereleases for beta tags:
+
+```text
+2.0.0-beta.3
+```
+
+Use stable semver for stable tags:
+
+```text
+2.0.0
+```
+
+CLI prereleases must use the `beta` channel. Other prerelease identifiers are rejected by `release:check`.
+
+### 2. Verify the CLI Locally
+
+Run the CLI check set:
+
+```bash
+devbox run -- pnpm --filter @better-webhook/cli run format:check
+devbox run -- pnpm --filter @better-webhook/cli run lint
+devbox run -- pnpm --filter @better-webhook/cli run check-types
+devbox run -- pnpm --filter @better-webhook/cli run test
+```
+
+Build and smoke-test the local binary:
+
+```bash
+devbox run -- pnpm --filter @better-webhook/cli run build
+devbox run -- pnpm --filter @better-webhook/cli run cli:built -- version --verbose
+```
+
+Run full repo verification before merging:
+
+```bash
+devbox run -- pnpm run format:check
+devbox run -- pnpm run lint
+devbox run -- pnpm run check-types
+devbox run -- pnpm run test
+devbox run -- pnpm run build
+```
+
+### 3. Run the Dry Run Workflow
+
+Before publishing, run the manual GitHub workflow:
+
+```text
+CLI Release Dry Run
+```
+
+It validates formatting, linting, type checks, tests, GoReleaser snapshot packaging, generated npm package directories, and `npm pack --dry-run` for every CLI npm package.
+
+### 4. Merge to Main
+
+Merge the CLI release commit to `main`.
+
+Do not tag an unmerged commit. The release validator checks that the tagged commit is reachable from `origin/main`.
+
+### 5. Create an Annotated Tag
+
+Fetch and check out the merged `main` commit:
+
+```bash
+devbox run -- git fetch origin main --tags
+devbox run -- git checkout main
+devbox run -- git pull --ff-only origin main
+```
+
+Create an annotated tag matching the CLI version:
+
+```bash
+devbox run -- git tag -a cli/v2.0.0-beta.3 -m "CLI v2.0.0-beta.3"
+```
+
+For a stable release:
+
+```bash
+devbox run -- git tag -a cli/v2.0.0 -m "CLI v2.0.0"
+```
+
+Push the tag:
+
+```bash
+devbox run -- git push origin cli/v2.0.0-beta.3
+```
+
+The tag push triggers `.github/workflows/cli-release.yml`.
+
+### 6. Watch the CLI Release Workflow
+
+The workflow will:
+
+- Validate the tag and npm availability.
+- Run CLI format, lint, type check, and tests.
+- Run GoReleaser, which runs `go mod tidy` and builds release artifacts.
+- Create or update the GitHub Release for the tag.
+- Generate npm package directories.
+- Publish native platform packages.
+- Publish the wrapper package last.
+
+If `release:check` says a package version already exists on npm, do not rerun the same version as a new release. Bump the CLI version and create a new annotated tag.
+
+### 7. Verify CLI Publishing
+
+For a beta release:
+
+```bash
+devbox run -- npm view @better-webhook/cli@beta version dist-tags --json
+devbox run -- npm view @better-webhook/cli-darwin-arm64@beta version dist-tags --json
+devbox run -- npm view @better-webhook/cli-linux-x64@beta version dist-tags --json
+```
+
+For a stable release:
+
+```bash
+devbox run -- npm view @better-webhook/cli version dist-tags --json
+devbox run -- npm view @better-webhook/cli-darwin-arm64 version dist-tags --json
+devbox run -- npm view @better-webhook/cli-linux-x64 version dist-tags --json
+```
+
+Also verify the GitHub Release exists for the pushed tag and contains:
+
+- macOS arm64 tarball
+- macOS x64 tarball
+- Linux arm64 tarball
+- Linux x64 tarball
+- Windows x64 zip
+- checksum file
+
+### 8. Current CLI npm State to Remember
+
+As of 2026-04-26:
+
+- `@better-webhook/cli@beta` is `2.0.0-beta.2`.
+- `@better-webhook/cli@latest` is `3.10.1`, an older package shape with the `better-webhook` bin.
+- `@better-webhook/cli@dev` is `0.0.0-dev`; it is not part of the current Go CLI release flow.
+- The new Go CLI wrapper exposes the `bw` bin.
+
+Until a stable Go CLI version is published, use:
+
+```bash
+npm install @better-webhook/cli@beta
+```
+
+or:
+
+```bash
+npx @better-webhook/cli@beta
+```
+
+After the first stable Go CLI release, verify that `@better-webhook/cli@latest` points to the stable Go CLI version.
+
+## Failure Recovery
+
+If an SDK publish fails before any package is published, fix the issue and rerun the workflow.
+
+If an SDK publish partially succeeds, inspect npm for every package in the release. Changesets will skip already-published versions on rerun, but verify the workflow logs before assuming rerun safety.
+
+If a CLI release fails after some native platform packages publish but before the wrapper publishes, keep the same version only if `release:check` is adjusted or bypassed intentionally by a maintainer. The normal validator rejects any already-published package version, so the safer path is usually a new patch or beta version.
+
+If the CLI GitHub Release exists but npm publish failed, compare the release artifacts with the npm package version before deciding whether to delete/recreate anything. Avoid moving or deleting published npm versions; npm package versions are effectively immutable.

--- a/docs/how-tos/release-sdks-and-cli.md
+++ b/docs/how-tos/release-sdks-and-cli.md
@@ -246,14 +246,21 @@ Also verify the GitHub Release exists for the pushed tag and contains:
 - Windows x64 zip
 - checksum file
 
-### 8. Current CLI npm State to Remember
+### 8. Verify Current CLI npm State
 
-As of 2026-04-26:
+Before installing or recommending a CLI tag, check the current npm state:
 
-- `@better-webhook/cli@beta` is `2.0.0-beta.2`; this branch prepares `2.0.0-beta.3`.
-- `@better-webhook/cli@latest` is `3.10.1`, an older package shape with the `better-webhook` bin.
-- `@better-webhook/cli@dev` is `0.0.0-dev`; it is not part of the current Go CLI release flow.
+```bash
+devbox run -- npm view @better-webhook/cli dist-tags --json
+devbox run -- npm view @better-webhook/cli@beta version
+devbox run -- npm view @better-webhook/cli@latest version
+```
+
+Durable CLI package facts:
+
 - The new Go CLI wrapper exposes the `bw` bin.
+- Older `@better-webhook/cli@latest` versions may use the legacy `better-webhook` bin until a stable Go CLI release moves `latest`.
+- `@better-webhook/cli@dev` is not part of the current Go CLI release flow.
 
 Until a stable Go CLI version is published, use:
 

--- a/docs/understandings/release-pipeline-and-publishing.md
+++ b/docs/understandings/release-pipeline-and-publishing.md
@@ -161,15 +161,15 @@ The CLI release workflow resolves npm tags from `packages/cli/package.json`:
 - Stable versions publish with `--tag latest`.
 - Prerelease versions publish with `--tag beta`.
 
-As of this audit on 2026-04-26, npm shows:
+Dist-tags and published versions change over time. Verify current state before release:
 
-- SDK package `latest` tags match the package versions in this repo.
-- `@better-webhook/cli` has `beta` at `2.0.0-beta.2`; this branch prepares `2.0.0-beta.3`.
-- `@better-webhook/cli` has `latest` at `3.10.1`, which is an older npm package shape with `better-webhook` as its bin.
-- `@better-webhook/cli` also has a `dev` dist-tag at `0.0.0-dev`; it is unrelated to the current Go CLI release flow.
-- Native CLI packages are published at `2.0.0-beta.2`; their `beta` and `latest` tags both point there.
+```bash
+devbox run -- npm view @better-webhook/cli dist-tags --json
+devbox run -- npm view @better-webhook/cli@beta version
+devbox run -- npm view @better-webhook/cli@latest version
+```
 
-That means `npm install @better-webhook/cli` currently resolves the old `3.10.1` package, while `npm install @better-webhook/cli@beta` resolves the new Go CLI wrapper. The first stable Go CLI release will move the wrapper's `latest` tag if it is published successfully with a stable semver version.
+Use those results to confirm whether `latest` and `beta` point to the expected package generation. Until a stable Go CLI release moves `latest`, prefer the `beta` tag for the Go CLI wrapper.
 
 ## CI and Security Gates
 
@@ -187,6 +187,6 @@ That means `npm install @better-webhook/cli` currently resolves the old `3.10.1`
 - Do not use `pnpm dev` or `pnpm start` as part of release verification.
 - If repo-wide lint fails with an `ENOENT` for a temporary `packages/stripe` tsup config file during concurrent build-related work, rerun lint by itself after builds finish.
 - The CLI `release:check` intentionally fails if the current CLI version already exists on npm. That is expected after a tag has already published.
-- The current checkout is tagged `cli/v2.0.0-beta.2`; rerunning the CLI release check fails because `@better-webhook/cli-darwin-arm64@2.0.0-beta.2` already exists on npm.
+- For example, a checkout tagged `cli/vX.Y.Z` can fail `release:check` after publishing because `@better-webhook/cli-darwin-arm64@X.Y.Z` already exists on npm.
 - `devbox.json` currently pins `pnpm@10.28.0` while the root `packageManager` field says `pnpm@10.33.0`; CI uses the Devbox-pinned binary unless Devbox is updated.
 - SDK docs under `apps/docs/content` can drift from SDK behavior. SDK-facing changes should include a docs review before release.

--- a/docs/understandings/release-pipeline-and-publishing.md
+++ b/docs/understandings/release-pipeline-and-publishing.md
@@ -164,7 +164,7 @@ The CLI release workflow resolves npm tags from `packages/cli/package.json`:
 As of this audit on 2026-04-26, npm shows:
 
 - SDK package `latest` tags match the package versions in this repo.
-- `@better-webhook/cli` has `beta` at `2.0.0-beta.2`, matching this repo.
+- `@better-webhook/cli` has `beta` at `2.0.0-beta.2`; this branch prepares `2.0.0-beta.3`.
 - `@better-webhook/cli` has `latest` at `3.10.1`, which is an older npm package shape with `better-webhook` as its bin.
 - `@better-webhook/cli` also has a `dev` dist-tag at `0.0.0-dev`; it is unrelated to the current Go CLI release flow.
 - Native CLI packages are published at `2.0.0-beta.2`; their `beta` and `latest` tags both point there.

--- a/docs/understandings/release-pipeline-and-publishing.md
+++ b/docs/understandings/release-pipeline-and-publishing.md
@@ -1,0 +1,192 @@
+# Release Pipeline and Publishing Understanding
+
+This repo has two separate publishing systems:
+
+- SDK packages are TypeScript npm packages published with Changesets from `main`.
+- The CLI is a Go binary distributed through GitHub Releases and npm wrapper packages from annotated `cli/v*` tags.
+
+The split is intentional. `.changeset/config.json` ignores `@better-webhook/cli`, so CLI releases never flow through Changesets.
+
+## Publishable Packages
+
+The public SDK packages are:
+
+- `@better-webhook/core`
+- `@better-webhook/express`
+- `@better-webhook/gcp-functions`
+- `@better-webhook/github`
+- `@better-webhook/hono`
+- `@better-webhook/nestjs`
+- `@better-webhook/nextjs`
+- `@better-webhook/otel`
+- `@better-webhook/ragie`
+- `@better-webhook/recall`
+- `@better-webhook/resend`
+- `@better-webhook/stripe`
+
+The CLI npm packages are:
+
+- `@better-webhook/cli`
+- `@better-webhook/cli-darwin-arm64`
+- `@better-webhook/cli-darwin-x64`
+- `@better-webhook/cli-linux-arm64`
+- `@better-webhook/cli-linux-x64`
+- `@better-webhook/cli-win32-x64`
+
+Workspace-only packages such as `@better-webhook/eslint-config` and `@better-webhook/typescript-config` are private/internal support packages and are not part of the release flow.
+
+## Shared Tooling
+
+All repo commands are expected to run through Devbox:
+
+```bash
+devbox run -- pnpm run format:check
+devbox run -- pnpm run lint
+devbox run -- pnpm run check-types
+devbox run -- pnpm run test
+devbox run -- pnpm run build
+```
+
+`devbox.json` pins the toolchain used by local work and CI, including Node, pnpm, Go, GoReleaser, golangci-lint, gofumpt, goimports, just, and Trivy. The root `packageManager` field is advisory for package-manager metadata; Devbox controls the `pnpm` binary used by release commands in CI.
+
+`turbo.json` defines the repo task graph. `build` depends on upstream package builds and emits `dist/**`, `build/**`, `bin/**`, and `.next/**`. `lint`, `check-types`, and `test` depend on upstream builds, which means release verification can rebuild dependencies even when a command looks package-scoped.
+
+## SDK Release Flow
+
+SDK releases are controlled by `.github/workflows/release.yml`.
+
+The workflow runs on pushes to `main` when release-relevant paths change:
+
+- `.changeset/**`
+- SDK package directories under `packages/*`
+- root package and workspace metadata
+- `justfile`
+- the release workflow itself
+
+The workflow grants `contents: write`, `pull-requests: write`, and `id-token: write`. The npm auth setup uses `actions/setup-node` with the npm registry, and publishing relies on the registry credentials/trusted-publishing setup available to the workflow.
+
+The SDK workflow does this:
+
+1. Checks out the repo with full history.
+2. Installs and validates Devbox.
+3. Configures npm registry access.
+4. Installs dependencies with `pnpm install --frozen-lockfile`.
+5. Restores the Trivy cache.
+6. Runs Trivy as a blocking gate only when `TRIVY_ENFORCE=1`; otherwise it records a release report without failing the publish.
+7. Runs lint, type check, test, and build. The release workflow does not run `format:check`; formatting is enforced by CI and local release readiness.
+8. Runs `changesets/action`.
+9. Either opens/updates a release PR or publishes packages.
+10. Pushes tags after a successful publish.
+
+Changesets config:
+
+- `baseBranch` is `main`.
+- `access` is `public`.
+- `commit` is `false`, so version/changelog files are not auto-committed by local `changeset version` commands.
+- `updateInternalDependencies` is `patch`, so dependents get patch bumps when internal workspace dependencies change.
+- `@better-webhook/cli` is ignored.
+
+Each SDK package builds with `tsup` into `dist`, publishes ESM, CJS, and TypeScript declarations, and restricts npm package contents to `dist`, `README.md`, and `LICENSE`.
+
+Provider packages with event subpath exports include additional `tsup` entries and package `exports` entries. The current event subpaths are `@better-webhook/github/events`, `@better-webhook/ragie/events`, `@better-webhook/recall/events`, `@better-webhook/resend/events`, and `@better-webhook/stripe/events`. Release checks should verify those subpath artifacts exist in `dist`.
+
+## SDK Versioning and Changelogs
+
+Feature PRs should add `.changeset/*.md` files with the user-facing summary and selected semver bumps. They should not manually edit package versions or package changelogs.
+
+When the release PR is created by the Changesets action, it applies the accumulated changesets to package versions, changelogs, and workspace dependency ranges. Merging that release PR back to `main` causes the next release workflow run to publish the packages.
+
+The root script for local versioning is:
+
+```bash
+devbox run -- pnpm run changeset:version
+```
+
+The matching root script is `changeset:version`; there is no `release:version` script.
+
+## CLI Release Flow
+
+CLI releases are controlled by `.github/workflows/cli-release.yml`.
+
+The workflow runs only when a tag matching `cli/v*` is pushed. The release tag must be annotated, must point to a commit reachable from `origin/main`, and must match the version in `packages/cli/package.json`.
+
+The CLI is a Go module in `packages/cli`. The npm package is private in the workspace so it is not accidentally published by workspace or Changesets tooling. The release workflow generates publishable npm package directories under `packages/cli/dist/npm`.
+
+The CLI workflow does this:
+
+1. Checks out the repo with full history and no persisted GitHub credentials.
+2. Installs and validates Devbox.
+3. Configures npm registry access.
+4. Installs dependencies with `pnpm install --frozen-lockfile`.
+5. Runs `pnpm --filter @better-webhook/cli run release:check`.
+6. Runs CLI format, lint, type check, and test.
+7. Runs GoReleaser to run `go mod tidy` and build archives without publishing.
+8. Creates or updates the GitHub Release for the tag.
+9. Generates npm wrapper and platform package directories.
+10. Publishes native platform packages first.
+11. Publishes `@better-webhook/cli` last.
+
+`packages/cli/scripts/validate-release.mjs` enforces:
+
+- A `cli/v<version>` tag exists.
+- The tag version equals `packages/cli/package.json`.
+- The remote tag is annotated.
+- The tagged commit is an ancestor of `origin/main`.
+- None of the wrapper or platform packages already exists on npm at that version.
+- Prerelease versions use the `beta` npm dist-tag.
+
+`packages/cli/.goreleaser.yml` runs `go mod tidy` before building and builds five targets:
+
+- macOS arm64
+- macOS x64
+- Linux arm64
+- Linux x64
+- Windows x64
+
+Windows arm64 is intentionally ignored. GoReleaser injects version, commit, date, and `builtBy=goreleaser` through linker flags.
+
+The npm wrapper package exposes the `bw` bin at `npm/bin/bw.js`. That script resolves the current platform-specific optional dependency and executes its native binary. Unsupported platforms fail with a clear error before trying to spawn a binary.
+
+`packages/cli/scripts/package-npm.mjs` creates:
+
+- One native npm package per supported platform, each containing only `bin`, `README.md`, and `LICENSE`.
+- One wrapper package, `@better-webhook/cli`, with `optionalDependencies` pointing to every native platform package at the same version.
+
+Native packages publish before the wrapper so users installing the wrapper can resolve the optional dependency immediately.
+
+## CLI Dist-Tags
+
+The CLI release workflow resolves npm tags from `packages/cli/package.json`:
+
+- Stable versions publish with `--tag latest`.
+- Prerelease versions publish with `--tag beta`.
+
+As of this audit on 2026-04-26, npm shows:
+
+- SDK package `latest` tags match the package versions in this repo.
+- `@better-webhook/cli` has `beta` at `2.0.0-beta.2`, matching this repo.
+- `@better-webhook/cli` has `latest` at `3.10.1`, which is an older npm package shape with `better-webhook` as its bin.
+- `@better-webhook/cli` also has a `dev` dist-tag at `0.0.0-dev`; it is unrelated to the current Go CLI release flow.
+- Native CLI packages are published at `2.0.0-beta.2`; their `beta` and `latest` tags both point there.
+
+That means `npm install @better-webhook/cli` currently resolves the old `3.10.1` package, while `npm install @better-webhook/cli@beta` resolves the new Go CLI wrapper. The first stable Go CLI release will move the wrapper's `latest` tag if it is published successfully with a stable semver version.
+
+## CI and Security Gates
+
+`.github/workflows/ci.yml` runs format, lint, type check, test, and build on pushes and pull requests targeting `main` or `develop`.
+
+`.github/workflows/security.yml` runs Trivy on pushes and pull requests. It uploads SARIF to GitHub code scanning. `TRIVY_ENFORCE=1` makes the Trivy scan blocking; otherwise it reports findings without failing the job.
+
+`.github/workflows/security-cache.yml` refreshes Trivy DB caches daily and on manual dispatch.
+
+`.github/workflows/cli-release-dry-run.yml` is a manual packaging rehearsal for the CLI. It runs CLI checks, GoReleaser snapshot packaging, npm package generation, and `npm pack --dry-run` for all generated npm package directories. It does not publish.
+
+## Operational Watch Points
+
+- Run all release commands through `devbox run --`.
+- Do not use `pnpm dev` or `pnpm start` as part of release verification.
+- If repo-wide lint fails with an `ENOENT` for a temporary `packages/stripe` tsup config file during concurrent build-related work, rerun lint by itself after builds finish.
+- The CLI `release:check` intentionally fails if the current CLI version already exists on npm. That is expected after a tag has already published.
+- The current checkout is tagged `cli/v2.0.0-beta.2`; rerunning the CLI release check fails because `@better-webhook/cli-darwin-arm64@2.0.0-beta.2` already exists on npm.
+- `devbox.json` currently pins `pnpm@10.28.0` while the root `packageManager` field says `pnpm@10.33.0`; CI uses the Devbox-pinned binary unless Devbox is updated.
+- SDK docs under `apps/docs/content` can drift from SDK behavior. SDK-facing changes should include a docs review before release.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,4 +26,4 @@ bw version --format json
 
 ## Release model
 
-CLI releases are separate from SDK Changesets releases. Maintainers publish real CLI releases from annotated tags such as `cli/v2.0.0-beta.2`. Beta versions publish to the npm `beta` dist-tag and stable versions publish to `latest`.
+CLI releases are separate from SDK Changesets releases. Maintainers publish real CLI releases from annotated tags such as `cli/v2.0.0-beta.3`. Beta versions publish to the npm `beta` dist-tag and stable versions publish to `latest`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,7 @@ bw
 bw --version
 bw version
 bw version --verbose
+bw version --format json
 ```
 
 ## Release model

--- a/packages/cli/internal/cli/root.go
+++ b/packages/cli/internal/cli/root.go
@@ -67,6 +67,9 @@ func printVersion(out io.Writer, build BuildInfo, opts versionOptions) error {
 	case "human":
 		return printHumanVersion(out, build, opts.verbose)
 	case "json":
+		if opts.verbose {
+			return fmt.Errorf("unsupported flag combination: --verbose only applies to human format")
+		}
 		return printJSONVersion(out, build)
 	default:
 		return fmt.Errorf("unsupported output format %q: expected human or json", opts.format)

--- a/packages/cli/internal/cli/root.go
+++ b/packages/cli/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -27,22 +28,52 @@ func NewRootCommand(build BuildInfo) *cobra.Command {
 
 func newVersionCommand(build BuildInfo) *cobra.Command {
 	var verbose bool
+	var format string
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
-			return printVersion(out, build, verbose)
+			return printVersion(out, build, versionOptions{
+				format:  format,
+				verbose: verbose,
+			})
 		},
 	}
 
+	cmd.Flags().StringVar(&format, "format", "human", "output format: human or json")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "print release metadata")
 
 	return cmd
 }
 
-func printVersion(out io.Writer, build BuildInfo, verbose bool) error {
+type versionOptions struct {
+	format  string
+	verbose bool
+}
+
+type versionOutput struct {
+	SchemaVersion string `json:"schemaVersion"`
+	Command       string `json:"command"`
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	Date          string `json:"date"`
+	BuiltBy       string `json:"builtBy"`
+}
+
+func printVersion(out io.Writer, build BuildInfo, opts versionOptions) error {
+	switch opts.format {
+	case "human":
+		return printHumanVersion(out, build, opts.verbose)
+	case "json":
+		return printJSONVersion(out, build)
+	default:
+		return fmt.Errorf("unsupported output format %q: expected human or json", opts.format)
+	}
+}
+
+func printHumanVersion(out io.Writer, build BuildInfo, verbose bool) error {
 	if !verbose {
 		_, err := fmt.Fprintf(out, "bw version %s\n", build.Version)
 		return err
@@ -57,4 +88,16 @@ func printVersion(out io.Writer, build BuildInfo, verbose bool) error {
 		build.BuiltBy,
 	)
 	return err
+}
+
+func printJSONVersion(out io.Writer, build BuildInfo) error {
+	encoder := json.NewEncoder(out)
+	return encoder.Encode(versionOutput{
+		SchemaVersion: "1",
+		Command:       "version",
+		Version:       build.Version,
+		Commit:        build.Commit,
+		Date:          build.Date,
+		BuiltBy:       build.BuiltBy,
+	})
 }

--- a/packages/cli/internal/cli/root_test.go
+++ b/packages/cli/internal/cli/root_test.go
@@ -97,10 +97,25 @@ func TestVersionCommandJSONFormat(t *testing.T) {
 		"builtBy":       "test",
 	}
 
+	if len(parsed) != len(expected) {
+		t.Fatalf("expected %d JSON fields, got %d in %q", len(expected), len(parsed), output)
+	}
+
 	for key, value := range expected {
 		if parsed[key] != value {
 			t.Fatalf("expected %s to be %q, got %q in %q", key, value, parsed[key], output)
 		}
+	}
+}
+
+func TestVersionCommandRejectsVerboseJSONFormat(t *testing.T) {
+	_, err := execute("version", "--verbose", "--format", "json")
+	if err == nil {
+		t.Fatal("expected verbose JSON format to fail")
+	}
+
+	if !strings.Contains(err.Error(), "--verbose only applies to human format") {
+		t.Fatalf("expected verbose JSON format error, got %v", err)
 	}
 }
 

--- a/packages/cli/internal/cli/root_test.go
+++ b/packages/cli/internal/cli/root_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -73,6 +74,44 @@ func TestVerboseVersionCommand(t *testing.T) {
 		if !strings.Contains(output, line) {
 			t.Fatalf("expected output to contain %q, got %q", line, output)
 		}
+	}
+}
+
+func TestVersionCommandJSONFormat(t *testing.T) {
+	output, err := execute("version", "--format", "json")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("expected JSON output, got %q: %v", output, err)
+	}
+
+	expected := map[string]string{
+		"schemaVersion": "1",
+		"command":       "version",
+		"version":       "9.8.7-test.1",
+		"commit":        "abc123",
+		"date":          "2026-04-25T00:00:00Z",
+		"builtBy":       "test",
+	}
+
+	for key, value := range expected {
+		if parsed[key] != value {
+			t.Fatalf("expected %s to be %q, got %q in %q", key, value, parsed[key], output)
+		}
+	}
+}
+
+func TestVersionCommandRejectsUnsupportedFormat(t *testing.T) {
+	_, err := execute("version", "--format", "xml")
+	if err == nil {
+		t.Fatal("expected unsupported format to fail")
+	}
+
+	if !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("expected unsupported format error, got %v", err)
 	}
 }
 

--- a/packages/cli/internal/cli/version.go
+++ b/packages/cli/internal/cli/version.go
@@ -1,6 +1,6 @@
 package cli
 
-const defaultVersion = "2.0.0-beta.2"
+const defaultVersion = "2.0.0-beta.3"
 
 var (
 	version = defaultVersion

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@better-webhook/cli",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "private": true,
   "description": "Command line interface for better-webhook",
   "type": "module",

--- a/packages/cli/test/smoke.test.js
+++ b/packages/cli/test/smoke.test.js
@@ -32,3 +32,24 @@ test("local binary reports version from command and flag", () => {
   assert.equal(flag.status, 0);
   assert.equal(flag.stdout, expectedVersion);
 });
+
+test("local binary reports machine-readable version", () => {
+  assert.equal(
+    existsSync(binary),
+    true,
+    "run pnpm --filter @better-webhook/cli build before smoke tests",
+  );
+
+  const command = spawnSync(binary, ["version", "--format", "json"], {
+    encoding: "utf8",
+  });
+  assert.equal(command.status, 0);
+  assert.deepEqual(JSON.parse(command.stdout), {
+    schemaVersion: "1",
+    command: "version",
+    version: packageJson.version,
+    commit: "unknown",
+    date: "unknown",
+    builtBy: "source",
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--format json` flag to the `bw version` command, producing a structured JSON output with schema versioning for machine consumption. It also bumps the CLI to `2.0.0-beta.3`, fixes a stale script name in the changeset README, and adds two new release-pipeline documentation files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a minor style suggestion, no functional defects

All P0/P1 checks passed: invalid flag combinations are properly rejected, JSON output is well-tested via unit and smoke tests, and version numbers are consistent across package.json and version.go. The single finding is a P2 best-practice suggestion about HTML escaping in the JSON encoder.

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cli/internal/cli/root.go | Adds --format flag with human/json dispatch; invalid combinations are correctly rejected with errors; one minor style issue (HTML escaping in json.NewEncoder) |
| packages/cli/internal/cli/root_test.go | Adds unit tests for JSON format output, verbose+json rejection, and unsupported format rejection; coverage is thorough |
| packages/cli/test/smoke.test.js | Adds smoke test for machine-readable JSON version output against the built binary; correctly checks all schema fields |
| packages/cli/internal/cli/version.go | Version bumped from 2.0.0-beta.2 to 2.0.0-beta.3, consistent with package.json |
| packages/cli/package.json | Version bump to 2.0.0-beta.3 matches version.go; versions are in sync |
| .changeset/README.md | Fixes script name from pnpm release:version to pnpm run changeset:version to match the actual root script |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["bw version"] --> B{--format flag}
    B -- "human (default)" --> C{--verbose?}
    C -- "false" --> D["fmt: bw version X.Y.Z"]
    C -- "true" --> E["fmt: version + commit + date + built-by"]
    B -- "json" --> F{--verbose?}
    F -- "true" --> G["error: --verbose only applies to human format"]
    F -- "false" --> H["json.Encoder to versionOutput struct"]
    H --> I["{ schemaVersion, command, version, commit, date, builtBy }"]
    B -- "other" --> J["error: unsupported output format"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/cli/internal/cli/root.go
Line: 96-106

Comment:
**HTML escaping enabled by default in JSON encoder**

`json.NewEncoder` HTML-escapes `<`, `>`, and `&` by default (producing `\u003c`, `\u003e`, `\u0026`). Current build metadata fields won't trigger this, but if a future semver string or commit SHA ever contains those characters the output would be silently mangled. Adding `SetEscapeHTML(false)` makes the behavior explicit and clean for a machine-readable CLI format.

```suggestion
func printJSONVersion(out io.Writer, build BuildInfo) error {
	encoder := json.NewEncoder(out)
	encoder.SetEscapeHTML(false)
	return encoder.Encode(versionOutput{
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: reject verbose JSON version outpu..."](https://github.com/endalk200/better-webhook/commit/817b99be7ae006656dca286156faf8e73252ec87) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29756138)</sub>

<!-- /greptile_comment -->