### PR TITLE
docs(sdk): bundle agent guides with packages

### DIFF
--- a/.changeset/nine-sdk-docs.md
+++ b/.changeset/nine-sdk-docs.md
@@ -1,0 +1,10 @@
+---
+"@better-webhook/core": patch
+"@better-webhook/express": patch
+"@better-webhook/nextjs": patch
+"@better-webhook/stripe": patch
+"@better-webhook/github": patch
+"@better-webhook/otel": patch
+---
+
+Bundle agent-oriented SDK reference docs under `docs/index.md` in each TypeScript SDK package.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,18 +23,25 @@ jobs:
       fail-fast: false
       matrix:
         # "javascript-typescript" handles both JS and TS files
-        language: ["javascript-typescript"]
+        language: ["javascript-typescript", "go"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: packages/cli/go.mod
+          cache-dependency-path: packages/cli/go.sum
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
-          build-mode: none
+          build-mode: ${{ matrix.language == 'go' && 'autobuild' || 'none' }}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5

--- a/docs/how-tos/release-sdks-and-cli.md
+++ b/docs/how-tos/release-sdks-and-cli.md
@@ -41,7 +41,7 @@ devbox run -- bun run test
 devbox run -- bun run build
 ```
 
-The SDK release workflow itself runs lint, type check, test, and build after the Trivy gate. It does not run `format:check`, so run formatting checks before merging.
+The SDK release workflow itself runs format check, lint, type check, test, and build after the Trivy gate.
 
 If formatting fails, apply it and rerun the checks:
 
@@ -73,6 +73,7 @@ Review the release PR for:
 - Correct package version bumps.
 - Correct changelog entries.
 - Correct workspace dependency updates.
+- No `workspace:*` ranges in published runtime `dependencies`.
 - Docs changes when SDK behavior changed.
 - Passing CI and release workflow checks.
 

--- a/docs/understandings/release-pipeline-and-publishing.md
+++ b/docs/understandings/release-pipeline-and-publishing.md
@@ -13,15 +13,9 @@ The public SDK packages are:
 
 - `@better-webhook/core`
 - `@better-webhook/express`
-- `@better-webhook/gcp-functions`
 - `@better-webhook/github`
-- `@better-webhook/hono`
-- `@better-webhook/nestjs`
 - `@better-webhook/nextjs`
 - `@better-webhook/otel`
-- `@better-webhook/ragie`
-- `@better-webhook/recall`
-- `@better-webhook/resend`
 - `@better-webhook/stripe`
 
 The CLI npm packages are:
@@ -73,7 +67,7 @@ The SDK workflow does this:
 4. Installs dependencies with `bun install --frozen-lockfile`.
 5. Restores the Trivy cache.
 6. Runs Trivy as a blocking gate only when `TRIVY_ENFORCE=1`; otherwise it records a release report without failing the publish.
-7. Runs lint, type check, test, and build. The release workflow does not run `format:check`; formatting is enforced by CI and local release readiness.
+7. Runs format check, lint, type check, test, and build.
 8. Runs `changesets/action`.
 9. Either opens/updates a release PR or publishes packages.
 10. Pushes tags after a successful publish.
@@ -86,9 +80,20 @@ Changesets config:
 - `updateInternalDependencies` is `patch`, so dependents get patch bumps when internal workspace dependencies change.
 - `@better-webhook/cli` is ignored.
 
-Each SDK package builds with `tsup` into `dist`, publishes ESM, CJS, and TypeScript declarations, and restricts npm package contents to `dist`, `README.md`, and `LICENSE`.
+Each SDK package builds with `tsc --build` into `dist`, publishes ESM-only JavaScript plus TypeScript declarations, and exposes a single root package export:
 
-Provider packages with event subpath exports include additional `tsup` entries and package `exports` entries. The current event subpaths are `@better-webhook/github/events`, `@better-webhook/ragie/events`, `@better-webhook/recall/events`, `@better-webhook/resend/events`, and `@better-webhook/stripe/events`. Release checks should verify those subpath artifacts exist in `dist`.
+```json
+{
+  ".": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  }
+}
+```
+
+The SDK packages currently restrict npm package contents to `dist`, `docs`, `README.md`, and `LICENSE`. Provider packages do not publish event subpath exports in the current SDK shape.
+
+Publishable SDK package runtime dependencies must use npm-installable semver ranges. Do not publish `workspace:*` in `dependencies`; npm consumers cannot install packages whose runtime dependency metadata contains the workspace protocol. Workspace protocol ranges are acceptable for local-only `devDependencies` and example applications.
 
 ## SDK Versioning and Changelogs
 

--- a/packages/core/docs/index.md
+++ b/packages/core/docs/index.md
@@ -1,0 +1,168 @@
+# @better-webhook/core Agent Guide
+
+## Package role
+
+`@better-webhook/core` owns the provider-agnostic Webhook Handling Pipeline. Use it to create one Webhook Endpoint for one Provider Definition, verify raw delivery bytes before parsing, dispatch verified Webhook Events to Event Handlers, apply optional Idempotency and Replay Protection, map pipeline outcomes to HTTP responses, and emit Delivery Observability.
+
+Core does not know Stripe, GitHub, Express, Next.js, or OpenTelemetry-specific behavior. Provider packages supply Provider Definitions. Framework Adapter packages translate framework request/response objects into core contracts.
+
+## Install
+
+```sh
+npm install @better-webhook/core
+```
+
+Most applications also install one provider package and one framework adapter:
+
+```sh
+npm install @better-webhook/core @better-webhook/stripe @better-webhook/nextjs
+```
+
+## Primary APIs
+
+- `createWebhookEndpoint(options)`: creates a Webhook Endpoint with handlers registered up front.
+- `endpoint.handle(request)`: accepts a `RawDeliveryRequest` and returns a `WebhookResponse`.
+- `endpoint.handleWithResult(request)`: returns both the `WebhookResponse` and `PipelineResult`; useful for tests and custom observability.
+- `defaultResponsePolicy(result)`: maps pipeline outcomes to default JSON responses.
+
+`createWebhookEndpoint` options:
+
+- `provider`: required `ProviderDefinition`.
+- `handlers`: event-specific handlers plus optional `"*"` catch-all handler.
+- `endpointIdentity`: required when `idempotencyStore` or `replayStore` is configured.
+- `idempotencyStore`: optional event-level coordination store.
+- `idempotencyTtlMs`: optional TTL passed to the idempotency store.
+- `replayStore`: optional seen-delivery tracking store.
+- `replayWindowMs`: timestamp tolerance and replay-store TTL; default is 5 minutes.
+- `now`: clock override for signed timestamp replay checks.
+- `responsePolicy`: custom `PipelineResult` to `WebhookResponse` mapper.
+- `telemetry`: optional Delivery Observability hooks.
+- `catchAllHandlerScope`: `"all"` by default; `"unknown"` means the catch-all only handles unknown provider event types.
+
+## Adapter and provider authoring APIs
+
+- `toWebhookDelivery(request)`: converts a `RawDeliveryRequest` body into raw bytes.
+- `getHeaderValues(headers, name)`: reads raw header values case-insensitively while preserving multiple values.
+- `ProviderDefinition`: provider contract with `verify(delivery)` and `extractEvent(delivery)`.
+- `RawDeliveryRequest`: framework-neutral request shape with method, URL, raw headers, body, and optional abort signal.
+- `RawHeaderCapabilities`: adapter metadata describing raw body and duplicate-header preservation.
+
+## In-memory stores
+
+- `createMemoryIdempotencyStore()`: in-memory `IdempotencyStore` with `size()`.
+- `createMemoryReplayStore()`: in-memory `ReplayStore` with `size()`.
+
+These stores are for tests, examples, and local development. They are not durable production coordination stores.
+
+## Types and contracts
+
+Request and delivery contracts:
+
+- `RawHeaderValue`
+- `RawDeliveryRequest`
+- `RawHeaderCapabilities`
+- `WebhookDelivery`
+
+Provider contracts:
+
+- `ProviderDefinition`
+- `ProviderVerificationSuccess`
+- `ProviderVerificationFailure`
+- `ProviderVerificationResult`
+- `WebhookEvent`
+
+Handler and endpoint contracts:
+
+- `HandlerContext`
+- `EventHandler`
+- `EventHandlerMap`
+- `CatchAllHandlerScope`
+- `CreateWebhookEndpointOptions`
+- `WebhookEndpoint`
+
+Coordination contracts:
+
+- `IdempotencyReservation`
+- `IdempotencyStore`
+- `ReplayStore`
+
+Result, response, and telemetry contracts:
+
+- `PipelineResultStatus`
+- `PipelineResult`
+- `WebhookResponse`
+- `ResponsePolicy`
+- `TelemetryDeliveryStart`
+- `TelemetryDeliveryEnd`
+- `DeliveryTelemetryContext`
+- `DeliveryTelemetry`
+
+Event handlers receive a framework-neutral `HandlerContext` with `event`, `delivery`, and optional `signal`. They do not receive Express, Next.js, or provider SDK request objects.
+
+## Canonical example
+
+```ts
+import { createWebhookEndpoint, createMemoryIdempotencyStore } from "@better-webhook/core";
+import { stripe } from "@better-webhook/stripe";
+
+export const endpoint = createWebhookEndpoint({
+  provider: stripe({ signingSecret: process.env.STRIPE_WEBHOOK_SECRET! }),
+  endpointIdentity: "stripe-production",
+  idempotencyStore: createMemoryIdempotencyStore(),
+  handlers: {
+    "checkout.session.completed": async ({ event }) => {
+      event.payload.payment_status;
+    },
+    "invoice.paid": async ({ event }) => {
+      event.payload.status;
+    },
+    "*": async ({ event }) => {
+      event.type;
+    },
+  },
+});
+```
+
+## Behavior defaults
+
+Pipeline order:
+
+1. Read raw body bytes exactly once.
+2. Verify the delivery with the Provider Definition.
+3. Apply signed timestamp Replay Protection when the provider supplies a signed timestamp.
+4. Extract the provider Event Envelope and Event Payload.
+5. Validate coordination prerequisites, such as requiring an event id when Idempotency is configured.
+6. Apply optional Replay Store tracking.
+7. Apply optional event-level Idempotency.
+8. Dispatch the specific Event Handler or catch-all Event Handler.
+9. Finish telemetry and map the result to an HTTP response.
+
+Default responses:
+
+- `200`: `handled`, `ignored`, `duplicate`.
+- `409`: `in_progress`.
+- `400`: `rejected`, `unsupported`.
+- `500`: `handler_error`.
+
+Idempotency is disabled unless an `IdempotencyStore` is configured. Replay Store tracking is disabled unless a `ReplayStore` is configured. Provider signed timestamp replay checks run when the provider returns `signedTimestamp`.
+
+## Gotchas
+
+- One Webhook Endpoint is bound to one Provider.
+- Provider signatures must be verified against unmodified raw body bytes.
+- A parsed JSON body is not a valid replacement for raw delivery bytes.
+- Handler return values are ignored; resolving succeeds and throwing or rejecting fails.
+- Ignored events and completed duplicates return success by default.
+- Failed handlers release a reserved idempotency claim by default so a provider retry can process again.
+- `endpointIdentity` must be stable when coordination stores are configured because it scopes coordination keys.
+
+## Do / do not
+
+Do create endpoints with all handlers registered up front.
+Do use framework adapters to supply `RawDeliveryRequest` correctly.
+Do implement durable `IdempotencyStore` and `ReplayStore` implementations for production coordination.
+
+Do not put framework request objects in Event Handlers.
+Do not parse JSON before provider verification.
+Do not create one endpoint that accepts multiple providers.
+Do not use the in-memory stores as production durability.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/express/docs/index.md
+++ b/packages/express/docs/index.md
@@ -74,9 +74,7 @@ app.post(
 The adapter reports:
 
 - `preservesRawBodyBytes: true`
-- `preservesDuplicateHeaders: true`
-
-Duplicate-header preservation depends on Express exposing `req.rawHeaders`.
+- `preservesDuplicateHeaders: true` when Express exposes `req.rawHeaders`; otherwise the `req.headers` fallback may collapse duplicate header lines.
 
 ## Gotchas
 

--- a/packages/express/docs/index.md
+++ b/packages/express/docs/index.md
@@ -1,0 +1,96 @@
+# @better-webhook/express Agent Guide
+
+## Package role
+
+`@better-webhook/express` is the Express Framework Adapter for Better Webhook. It converts an Express-shaped request with a captured raw body into core's `RawDeliveryRequest`, then sends a core `WebhookResponse` through Express.
+
+This package does not verify provider signatures, parse provider events, apply Idempotency, apply Replay Protection, or dispatch Event Handlers. Those responsibilities stay in `@better-webhook/core` and the selected provider package.
+
+## Install
+
+```sh
+npm install @better-webhook/core @better-webhook/express
+```
+
+Most applications also install a provider package:
+
+```sh
+npm install @better-webhook/core @better-webhook/express @better-webhook/stripe
+```
+
+## Primary APIs
+
+- `createExpressMiddleware(endpoint)`: returns Express middleware that delegates to a Better Webhook Endpoint.
+- `toRawDeliveryRequest(request)`: converts an Express-shaped request into core's `RawDeliveryRequest`.
+- `sendExpressResponse(response, webhookResponse)`: writes a core `WebhookResponse` to an Express response.
+- `expressRawHeaderCapabilities`: adapter capability metadata.
+
+## Types and contracts
+
+- `ExpressWebhookRequest`: minimal request shape accepted by the adapter.
+- `ExpressWebhookResponse`: minimal response shape used by `sendExpressResponse`.
+- `ExpressNextFunction`: `next(error?)` callback type.
+
+`ExpressWebhookRequest` must include `rawBody`. It can be a `Buffer`, `Uint8Array`, or `string`. The adapter prefers `request.rawHeaders` when present so duplicate raw header lines are preserved; otherwise it falls back to `request.headers`.
+
+## Canonical example
+
+```ts
+import express from "express";
+import { createWebhookEndpoint } from "@better-webhook/core";
+import {
+  createExpressMiddleware,
+  type ExpressWebhookRequest,
+} from "@better-webhook/express";
+import { stripe } from "@better-webhook/stripe";
+
+const app = express();
+
+const endpoint = createWebhookEndpoint({
+  provider: stripe({ signingSecret: process.env.STRIPE_WEBHOOK_SECRET! }),
+  handlers: {
+    "invoice.paid": async ({ event }) => {
+      event.payload.status;
+    },
+  },
+});
+
+app.post(
+  "/webhooks/stripe",
+  express.raw({ type: "application/json" }),
+  (req, _res, next) => {
+    const expressRequest = req as ExpressWebhookRequest;
+    expressRequest.rawBody = req.body;
+    next();
+  },
+  createExpressMiddleware(endpoint),
+);
+```
+
+## Behavior defaults
+
+`toRawDeliveryRequest` throws when `request.rawBody` is missing because provider signatures cannot be verified from a parsed or reserialized body. `createExpressMiddleware` catches adapter or endpoint errors and passes them to `next(error)`.
+
+The adapter reports:
+
+- `preservesRawBodyBytes: true`
+- `preservesDuplicateHeaders: true`
+
+Duplicate-header preservation depends on Express exposing `req.rawHeaders`.
+
+## Gotchas
+
+- Register webhook routes before global `express.json()` middleware, or exclude webhook routes from parsed body middleware.
+- `req.body` only works here when it is the raw body produced by `express.raw()`.
+- Event Handlers do not receive Express `req`, `res`, or `next`.
+- The adapter does not choose provider response statuses; core's response policy does.
+
+## Do / do not
+
+Do capture raw body bytes before parsed body middleware mutates the request.
+Do pass a core `WebhookEndpoint` into `createExpressMiddleware`.
+Do keep provider verification in the Better Webhook pipeline.
+
+Do not call `express.json()` before the webhook route if it consumes the body.
+Do not reconstruct raw bodies with `JSON.stringify(req.body)`.
+Do not put Express response handling inside Event Handlers.

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/github/docs/index.md
+++ b/packages/github/docs/index.md
@@ -1,0 +1,122 @@
+# @better-webhook/github Agent Guide
+
+## Package role
+
+`@better-webhook/github` is the GitHub Provider Definition for Better Webhook. It verifies GitHub webhook deliveries, extracts the GitHub Event Envelope, exposes GitHub event metadata, and dispatches through core by GitHub webhook event name.
+
+This package authenticates incoming webhook deliveries. It does not authorize outgoing GitHub API calls and does not provide GitHub App JWTs, installation tokens, Octokit helpers, check runs, statuses, PR reviews, or comment write-back helpers.
+
+## Install
+
+```sh
+npm install @better-webhook/core @better-webhook/github
+```
+
+Most applications also install a framework adapter:
+
+```sh
+npm install @better-webhook/core @better-webhook/github @better-webhook/express
+```
+
+## Primary APIs
+
+- `github(options)`: creates a GitHub `ProviderDefinition`.
+- `knownGitHubEventTypes`: readonly list of curated GitHub event names.
+- `isKnownGitHubEventType(type)`: type guard for curated event names.
+
+`GitHubProviderOptions`:
+
+- `webhookSecret`: GitHub webhook secret for one Webhook Endpoint. It must be a non-empty string.
+
+The returned provider has `name: "github"` and reports replay key support. GitHub signatures do not include a signed timestamp.
+
+## Testing and low-level helpers
+
+- `computeGitHubSignature(secret, rawBody)`: computes the HMAC-SHA256 digest.
+- `createGitHubSignatureHeader(options)`: creates a `sha256=` signature header.
+- `parseGitHubSignatureHeader(header)`: parses and validates a `sha256=` signature header.
+- `createGitHubReplayKey(delivery)`: returns the `X-GitHub-Delivery` value or throws if missing.
+- `parseGitHubEnvelope(delivery)`: parses and validates the GitHub Event Envelope from raw delivery bytes and headers.
+- `readGitHubHeaders(headers)`: reads GitHub-specific raw headers.
+
+## Types and contracts
+
+Important exported types include `GitHubWebhookEvent`, `KnownGitHubEvent`, `UnknownGitHubEvent`, `KnownGitHubEventType`, `GitHubEventPayloads`, `GitHubEventEnvelope`, `GitHubPayload`, `GitHubUser`, `GitHubRepository`, `GitHubInstallation`, `GitHubPullRequest`, `GitHubIssueComment`, `GitHubCheckRun`, and `GitHubProviderOptions`.
+
+Handlers dispatch by GitHub webhook event name such as `pull_request`, `issue_comment`, or `check_run`. The payload `action` is exposed as `event.envelope.action`; action names are not flattened into handler keys.
+
+Curated event names:
+
+- `ping`
+- `installation`
+- `installation_repositories`
+- `pull_request`
+- `issue_comment`
+- `pull_request_review`
+- `pull_request_review_comment`
+- `pull_request_review_thread`
+- `check_run`
+- `check_suite`
+- `status`
+- `workflow_run`
+- `workflow_job`
+- `merge_group`
+
+## Canonical example
+
+```ts
+import { createWebhookEndpoint } from "@better-webhook/core";
+import { github } from "@better-webhook/github";
+
+export const endpoint = createWebhookEndpoint({
+  provider: github({ webhookSecret: process.env.GITHUB_WEBHOOK_SECRET! }),
+  handlers: {
+    pull_request: async ({ event }) => {
+      event.id;
+      event.envelope.action;
+      event.payload.pull_request;
+    },
+    "*": async ({ event }) => {
+      event.type;
+    },
+  },
+  catchAllHandlerScope: "unknown",
+});
+```
+
+## Behavior defaults
+
+Verification requires:
+
+- `content-type` with media type `application/json`.
+- `X-Hub-Signature-256` with a valid `sha256=` HMAC-SHA256 signature.
+- Signature computed over exact raw delivery bytes.
+
+Envelope validation requires:
+
+- non-empty `X-GitHub-Delivery`.
+- non-empty `X-GitHub-Event`.
+- JSON object body.
+- optional string `action`.
+- optional numeric `installation.id`.
+- optional numeric `repository.id`.
+
+`X-GitHub-Delivery` becomes the core Webhook Event id and the provider replay key. With an Idempotency Store, repeated deliveries with the same GitHub Delivery ID can become completed duplicates. With a Replay Store, repeated delivery keys are rejected as replayed deliveries before application handling.
+
+## Gotchas
+
+- GitHub manual redelivery reuses `X-GitHub-Delivery`; strict Idempotency or Replay Store settings can acknowledge or reject manual redeliveries before the handler runs.
+- GitHub signatures have no signed timestamp, so Replay Protection is store-only for this provider.
+- `application/x-www-form-urlencoded` payloads are intentionally unsupported.
+- Legacy SHA-1 signatures and unsigned mode are unsupported.
+- Payload object shapes are permissive so GitHub can add fields without forcing package updates.
+
+## Do / do not
+
+Do dispatch handlers by GitHub webhook event name.
+Do inspect `event.envelope.action` inside event handlers when action-specific behavior matters.
+Do enqueue long-running automation from handlers and acknowledge quickly.
+
+Do not write handlers keyed as `pull_request.opened`.
+Do not use webhook verification as authorization for outgoing GitHub API calls.
+Do not expect this package to create GitHub App tokens or API clients.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -117,6 +117,12 @@ export type GitHubEventPayloads = {
 
 export type KnownGitHubEventType = keyof GitHubEventPayloads;
 
+function defineKnownGitHubEventTypes<const TTypes extends readonly KnownGitHubEventType[]>(
+	types: Exclude<KnownGitHubEventType, TTypes[number]> extends never ? TTypes : never,
+): TTypes {
+	return types;
+}
+
 export type KnownGitHubEvent = {
 	[TType in KnownGitHubEventType]: WebhookEvent<
 		TType,
@@ -279,7 +285,7 @@ export function isKnownGitHubEventType(type: string): type is KnownGitHubEventTy
 	return knownGitHubEventTypes.includes(type as KnownGitHubEventType);
 }
 
-export const knownGitHubEventTypes = [
+export const knownGitHubEventTypes = defineKnownGitHubEventTypes([
 	"ping",
 	"installation",
 	"installation_repositories",
@@ -294,7 +300,7 @@ export const knownGitHubEventTypes = [
 	"workflow_run",
 	"workflow_job",
 	"merge_group",
-] as const satisfies readonly string[];
+] as const);
 
 function getGitHubSignatureHeader(headers: RawHeaderValue[]): string {
 	return getHeaderValues(headers, "x-hub-signature-256").join(",");

--- a/packages/github/test/github.test.ts
+++ b/packages/github/test/github.test.ts
@@ -8,6 +8,7 @@ import {
 	createGitHubSignatureHeader,
 	type GitHubWebhookEvent,
 	github,
+	type KnownGitHubEventType,
 	knownGitHubEventTypes,
 	parseGitHubSignatureHeader,
 	type UnknownGitHubEvent,
@@ -235,6 +236,8 @@ describe("github provider", () => {
 	});
 
 	it("classifies known events without inspecting action values", async () => {
+		expectTypeOf<(typeof knownGitHubEventTypes)[number]>().toEqualTypeOf<KnownGitHubEventType>();
+
 		const handler = vi.fn();
 		const endpoint = createWebhookEndpoint({
 			provider: github({ webhookSecret: secret }),

--- a/packages/nextjs/docs/index.md
+++ b/packages/nextjs/docs/index.md
@@ -1,0 +1,82 @@
+# @better-webhook/nextjs Agent Guide
+
+## Package role
+
+`@better-webhook/nextjs` is the Next.js App Router Framework Adapter for Better Webhook. It converts a Fetch-style route handler request into core's `RawDeliveryRequest`, then converts core's `WebhookResponse` into a standard `Response`.
+
+This package does not verify provider signatures, parse provider events, apply Idempotency, apply Replay Protection, or dispatch Event Handlers. Those responsibilities stay in `@better-webhook/core` and the selected provider package.
+
+## Install
+
+```sh
+npm install @better-webhook/core @better-webhook/nextjs
+```
+
+Most applications also install a provider package:
+
+```sh
+npm install @better-webhook/core @better-webhook/nextjs @better-webhook/stripe
+```
+
+## Primary APIs
+
+- `createNextRouteHandler(endpoint)`: returns a Next.js-compatible route handler function.
+- `toRawDeliveryRequest(request)`: converts a Fetch-style request into core's `RawDeliveryRequest`.
+- `toNextResponse(response)`: converts a core `WebhookResponse` into a Fetch `Response`.
+- `nextjsRawHeaderCapabilities`: adapter capability metadata.
+
+## Types and contracts
+
+- `NextWebhookRequest`: minimal request shape accepted by the adapter. It needs `method`, `url`, `headers`, `arrayBuffer()`, and optional `signal`.
+
+The adapter reads `request.arrayBuffer()` and passes those bytes to core. It maps `Headers.entries()` into raw header pairs and forwards the abort signal when present.
+
+## Canonical example
+
+```ts
+import { createWebhookEndpoint } from "@better-webhook/core";
+import { createNextRouteHandler } from "@better-webhook/nextjs";
+import { stripe } from "@better-webhook/stripe";
+
+const endpoint = createWebhookEndpoint({
+  provider: stripe({ signingSecret: process.env.STRIPE_WEBHOOK_SECRET! }),
+  handlers: {
+    "checkout.session.completed": async ({ event }) => {
+      event.payload.payment_status;
+    },
+    "invoice.paid": async ({ event }) => {
+      event.payload.status;
+    },
+  },
+});
+
+export const runtime = "nodejs";
+export const POST = createNextRouteHandler(endpoint);
+```
+
+## Behavior defaults
+
+The adapter reports:
+
+- `preservesRawBodyBytes: true`
+- `preservesDuplicateHeaders: false`
+
+Fetch `Headers` preserve signature-relevant values but do not expose duplicate raw header lines. The adapter returns whatever status, headers, and body core's response policy produced.
+
+## Gotchas
+
+- Use the Next.js Node.js runtime for the initial SDK release.
+- Do not call `request.json()` before passing the request to Better Webhook.
+- A route handler request body can only be consumed once; let the adapter read it.
+- Event Handlers do not receive the Next.js request object.
+- Edge runtime support is outside the initial SDK scope.
+
+## Do / do not
+
+Do export `runtime = "nodejs"` in route files using this adapter.
+Do create the endpoint outside the route handler when possible.
+Do pass the route request directly to the generated handler.
+
+Do not parse or clone the body before signature verification.
+Do not implement provider verification in the route handler.
+Do not return custom HTTP responses from Event Handlers.

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/otel/docs/index.md
+++ b/packages/otel/docs/index.md
@@ -1,0 +1,100 @@
+# @better-webhook/otel Agent Guide
+
+## Package role
+
+`@better-webhook/otel` is the OpenTelemetry bridge for Better Webhook Delivery Observability. It implements core's `DeliveryTelemetry` contract by creating one span per Webhook Delivery and recording pipeline outcome attributes.
+
+This package does not configure an OpenTelemetry SDK, exporter, or resource. It does not verify providers, adapt framework requests, parse events, or change pipeline behavior.
+
+## Install
+
+```sh
+npm install @better-webhook/core @better-webhook/otel @opentelemetry/api
+```
+
+Most applications also install a provider and framework adapter:
+
+```sh
+npm install @better-webhook/stripe @better-webhook/nextjs
+```
+
+`@opentelemetry/api` is needed for the example below. The package contract only requires an object matching the exported `OtelTracer` shape.
+
+## Primary APIs
+
+- `otel(options)`: creates a core `DeliveryTelemetry` implementation.
+
+`OtelOptions`:
+
+- `tracer`: object with `startSpan(name, options?)`.
+
+The span name is `better_webhook.delivery`.
+
+## Types and contracts
+
+- `OtelTracer`: minimal tracer contract compatible with `@opentelemetry/api` tracers.
+- `OtelSpan`: minimal span contract with `setAttribute`, optional `addEvent`, optional `recordException`, and `end`.
+- `OtelOptions`: options accepted by `otel()`.
+
+The bridge accepts the small structural tracer/span contracts instead of importing OpenTelemetry types directly.
+
+## Canonical example
+
+```ts
+import { trace } from "@opentelemetry/api";
+import { createWebhookEndpoint } from "@better-webhook/core";
+import { otel } from "@better-webhook/otel";
+import { stripe } from "@better-webhook/stripe";
+
+export const endpoint = createWebhookEndpoint({
+  provider: stripe({ signingSecret: process.env.STRIPE_WEBHOOK_SECRET! }),
+  telemetry: otel({ tracer: trace.getTracer("webhooks") }),
+  handlers: {
+    "invoice.paid": async ({ event }) => {
+      event.payload.status;
+    },
+  },
+});
+```
+
+## Behavior defaults
+
+The span starts with:
+
+- `webhook.provider`
+- `http.request.method`
+- `url.full`
+
+When the delivery finishes, the bridge records:
+
+- `webhook.event.type`
+- `webhook.event.id`
+- `webhook.result`
+- `webhook.verification`
+- `webhook.replay`
+- `webhook.idempotency`
+- `webhook.handler`
+- `http.response.status_code`
+- `webhook.duplicate`
+- `webhook.ignored`
+- `webhook.rejected`
+- `webhook.reason`
+
+Optional attributes are only set when core supplies a value. Payload contents are not recorded by default.
+
+## Gotchas
+
+- Configure the OpenTelemetry SDK and exporter in the application; this package only consumes a tracer.
+- If the telemetry context is not span-shaped, finish and error hooks do nothing.
+- Errors recorded by core are sanitized to provider, error name, and message.
+- The bridge ends the delivery span when core finishes processing the Webhook Delivery.
+
+## Do / do not
+
+Do pass `otel({ tracer })` to `createWebhookEndpoint({ telemetry })`.
+Do keep payload recording out of traces unless the application explicitly owns that policy elsewhere.
+Do use normal OpenTelemetry setup for exporters, resources, sampling, and context propagation.
+
+Do not expect this package to initialize OpenTelemetry.
+Do not add provider payloads to span attributes by default.
+Do not use telemetry hooks to change webhook response behavior.

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/stripe/docs/index.md
+++ b/packages/stripe/docs/index.md
@@ -1,0 +1,111 @@
+# @better-webhook/stripe Agent Guide
+
+## Package role
+
+`@better-webhook/stripe` is the Stripe Provider Definition for Better Webhook. It supplies Stripe signature verification, signed timestamp metadata, replay key generation, Event Envelope extraction, and curated compile-time Event Payload types to `@better-webhook/core`.
+
+This package does not read framework requests, send HTTP responses, own the Webhook Handling Pipeline, or depend on the official Stripe package for webhook verification.
+
+## Install
+
+```sh
+npm install @better-webhook/core @better-webhook/stripe
+```
+
+Most applications also install a framework adapter:
+
+```sh
+npm install @better-webhook/core @better-webhook/stripe @better-webhook/nextjs
+```
+
+## Primary APIs
+
+- `stripe(options)`: creates a Stripe `ProviderDefinition`.
+
+`StripeProviderOptions`:
+
+- `signingSecret`: Stripe webhook signing secret for one Webhook Endpoint.
+
+The returned provider has `name: "stripe"` and reports support for signed timestamps and replay keys.
+
+## Testing helpers
+
+- `parseStripeSignatureHeader(header)`: parses `Stripe-Signature` into `{ timestamp, signatures }`.
+- `computeStripeSignature(secret, timestamp, rawBody)`: computes the HMAC-SHA256 `v1` signature for `{timestamp}.{rawBodyBytes}`.
+- `createStripeSignatureHeader(options)`: creates a Stripe-style signature header; useful in tests.
+- `createStripeReplayKey(timestamp, signature, rawBody)`: creates the replay key shape used by this provider.
+
+## Types and contracts
+
+Important exported types include `StripeWebhookEvent`, `KnownStripeEvent`, `UnknownStripeEvent`, `KnownStripeEventType`, `StripeEventPayloads`, `StripeEventEnvelope`, `StripeObject`, `StripeCheckoutSession`, `StripeInvoice`, `StripeSubscription`, `StripePaymentIntent`, and `StripeProviderOptions`.
+
+Known event handlers receive typed payloads for the curated map. Unknown verified Stripe events remain accepted with `known: false` and can be handled by the catch-all Event Handler.
+
+Curated event types:
+
+- `checkout.session.completed`
+- `checkout.session.expired`
+- `invoice.paid`
+- `invoice.payment_failed`
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+- `payment_intent.succeeded`
+- `payment_intent.payment_failed`
+
+## Canonical example
+
+```ts
+import { createWebhookEndpoint } from "@better-webhook/core";
+import { stripe } from "@better-webhook/stripe";
+
+export const endpoint = createWebhookEndpoint({
+  provider: stripe({ signingSecret: process.env.STRIPE_WEBHOOK_SECRET! }),
+  handlers: {
+    "checkout.session.completed": async ({ event }) => {
+      event.payload.payment_status;
+      event.payload.customer;
+    },
+    "invoice.paid": async ({ event }) => {
+      event.payload.status;
+      event.payload.subscription;
+    },
+    "*": async ({ event }) => {
+      if (!event.known) {
+        event.type;
+      }
+    },
+  },
+});
+```
+
+## Behavior defaults
+
+Stripe verification requires a valid `Stripe-Signature` header with a timestamp and at least one `v1` signature. Signatures are checked against exact raw delivery bytes.
+
+Envelope validation requires:
+
+- `id` as a non-empty string.
+- `object` equal to `"event"`.
+- `type` as a non-empty string.
+- `created` as a number.
+- `data.object` present.
+
+Core applies default signed timestamp Replay Protection when Stripe verification returns a signed timestamp. If a Replay Store is configured, the replay key combines the timestamp, matched signature, and raw body digest.
+
+## Gotchas
+
+- The Stripe Provider Secret is directly configured; dynamic per-tenant secret resolution is outside the initial SDK design.
+- Runtime validation is envelope-only. Stripe payload object shapes are not fully validated at runtime.
+- Raw body bytes must be original. Re-serialized JSON will usually fail signature verification.
+- Multiple `v1` signatures are supported; any matching signature is accepted.
+
+## Do / do not
+
+Do pair this provider with `@better-webhook/core` and a Framework Adapter.
+Do use typed event handlers for curated event types.
+Do use `"*"` for verified Stripe events outside the curated map when needed.
+
+Do not parse the request body before verification.
+Do not use Stripe event type strings as provider names.
+Do not assume compile-time payload types imply full runtime payload validation.

--- a/packages/stripe/package.json
+++ b/packages/stripe/package.json
@@ -11,6 +11,7 @@
 	},
 	"files": [
 		"dist",
+		"docs",
 		"README.md",
 		"LICENSE"
 	],

--- a/packages/stripe/src/index.ts
+++ b/packages/stripe/src/index.ts
@@ -93,6 +93,10 @@ export type StripeProviderOptions = {
 };
 
 export function stripe(options: StripeProviderOptions): ProviderDefinition<StripeWebhookEvent> {
+	if (typeof options.signingSecret !== "string" || options.signingSecret.length === 0) {
+		throw new Error("Stripe Provider Secret is required");
+	}
+
 	return {
 		name: "stripe",
 		capabilities: {

--- a/packages/stripe/test/stripe.test.ts
+++ b/packages/stripe/test/stripe.test.ts
@@ -40,6 +40,15 @@ function request(
 }
 
 describe("stripe provider", () => {
+	it("requires a configured signing secret", () => {
+		expect(() => stripe({ signingSecret: "" })).toThrow("Stripe Provider Secret is required");
+		expect(() =>
+			stripe({
+				signingSecret: undefined as unknown as string,
+			}),
+		).toThrow("Stripe Provider Secret is required");
+	});
+
 	it("verifies real Stripe HMAC semantics over raw bytes", async () => {
 		const handler = vi.fn();
 		const endpoint = createWebhookEndpoint({


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles agent-oriented reference guides (`docs/index.md`) into each TypeScript SDK package, adds those docs to each package's published `files`, and ships two runtime/type-safety improvements alongside. Internal docs are updated to reflect the current build toolchain and package list.

- **Docs**: Six new `docs/index.md` agent guides (core, express, github, nextjs, otel, stripe) added and included in npm package contents via `\"docs\"` entry in each `package.json`.
- **GitHub provider**: Adds `defineKnownGitHubEventTypes`, a module-internal TypeScript helper that makes the `knownGitHubEventTypes` array fail to compile if any `KnownGitHubEventType` is missing; a matching `expectTypeOf` test is added.
- **Stripe provider**: Adds a runtime guard that throws immediately when `signingSecret` is empty or non-string, consistent with the pre-existing guard in the GitHub provider; two new test cases cover it.
- **CodeQL workflow**: Adds Go to the language matrix with a conditional `autobuild` mode and a guarded `setup-go` step for the CLI package.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive documentation, minor type safety hardening, and a validation guard consistent with existing provider patterns.

All code changes are tightly scoped: the stripe validation guard mirrors the pre-existing github guard, the TypeScript exhaustiveness helper carries no runtime cost, and the docs additions are publish-only artifacts. No logic paths, existing behaviors, or public APIs are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .changeset/nine-sdk-docs.md | New changeset file marking all six SDK packages for a patch bump to record the docs addition. |
| .github/workflows/codeql.yml | Adds Go to the CodeQL scan matrix; conditionally sets up Go toolchain and switches build-mode to autobuild for Go while keeping none for JS/TS. |
| packages/github/src/index.ts | Adds compile-time exhaustiveness check via `defineKnownGitHubEventTypes`; ensures `knownGitHubEventTypes` covers every `KnownGitHubEventType`. |
| packages/stripe/src/index.ts | Adds runtime guard that throws immediately when `signingSecret` is missing or empty, consistent with the pre-existing guard in the github provider. |
| packages/stripe/test/stripe.test.ts | New test cases cover empty string and undefined signingSecret. |
| packages/github/test/github.test.ts | Adds a `expectTypeOf` assertion that the `knownGitHubEventTypes` array element union equals `KnownGitHubEventType`. |
| docs/understandings/release-pipeline-and-publishing.md | Updates the public package list, corrects build tool description, and documents the workspace:* restriction. |
| packages/core/docs/index.md | New agent guide for `@better-webhook/core`. |
| packages/stripe/docs/index.md | New agent guide for `@better-webhook/stripe`. |
| packages/github/docs/index.md | New agent guide for `@better-webhook/github`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(providers): validate secrets and kno..."](https://github.com/endalk200/better-webhook/commit/ecfe83ea07d1c7d6b83023b27159ba9be5130223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34539360)</sub>

<!-- /greptile_comment -->