### PR TITLE
feat(github): use generated webhook payload types

### DIFF
--- a/.changeset/github-webhook-payload-types.md
+++ b/.changeset/github-webhook-payload-types.md
@@ -1,5 +1,5 @@
 ---
-"@better-webhook/github": minor
+"@better-webhook/github": major
 "@better-webhook/core": minor
 ---
 

--- a/.changeset/github-webhook-payload-types.md
+++ b/.changeset/github-webhook-payload-types.md
@@ -1,0 +1,8 @@
+---
+"@better-webhook/github": minor
+"@better-webhook/core": minor
+---
+
+Use GitHub's generated OpenAPI webhook schemas for known event payload types so handlers receive action-aware, fully typed payloads.
+
+Fix Event Handler map narrowing when a provider event union includes both literal known events and an unknown catch-all string event.

--- a/bun.lock
+++ b/bun.lock
@@ -104,7 +104,7 @@
       "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
-        "@octokit/openapi-webhooks-types": "^12.1.0",
+        "@octokit/openapi-webhooks-types": "12.1.0",
       },
       "devDependencies": {
         "@better-webhook/biome-config": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -76,7 +76,7 @@
     },
     "packages/core": {
       "name": "@better-webhook/core",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "devDependencies": {
         "@better-webhook/biome-config": "workspace:*",
         "@better-webhook/typescript-config": "workspace:*",
@@ -86,7 +86,7 @@
     },
     "packages/express": {
       "name": "@better-webhook/express",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
       },
@@ -101,9 +101,10 @@
     },
     "packages/github": {
       "name": "@better-webhook/github",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
+        "@octokit/openapi-webhooks-types": "^12.1.0",
       },
       "devDependencies": {
         "@better-webhook/biome-config": "workspace:*",
@@ -115,7 +116,7 @@
     },
     "packages/nextjs": {
       "name": "@better-webhook/nextjs",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
       },
@@ -129,7 +130,7 @@
     },
     "packages/otel": {
       "name": "@better-webhook/otel",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
       },
@@ -142,7 +143,7 @@
     },
     "packages/stripe": {
       "name": "@better-webhook/stripe",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@better-webhook/core": "workspace:*",
       },
@@ -394,6 +395,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -78,6 +78,9 @@ type LiteralEventType<TType extends string> = string extends TType ? never : TTy
 type LiteralEventTypes<TEvents extends WebhookEvent> =
 	TEvents extends WebhookEvent<infer TType> ? LiteralEventType<TType> : never;
 
+type BroadStringEvents<TEvents extends WebhookEvent> =
+	TEvents extends WebhookEvent<infer TType> ? (string extends TType ? TEvents : never) : never;
+
 type EventHandlerTypeKeys<TEvents extends WebhookEvent> = [LiteralEventTypes<TEvents>] extends [
 	never,
 ]
@@ -87,6 +90,9 @@ type EventHandlerTypeKeys<TEvents extends WebhookEvent> = [LiteralEventTypes<TEv
 export type EventHandlerMap<TEvents extends WebhookEvent> = {
 	[TType in EventHandlerTypeKeys<TEvents>]?: EventHandler<Extract<TEvents, { type: TType }>>;
 } & {
+	unknown?: [BroadStringEvents<TEvents>] extends [never]
+		? never
+		: Record<string, EventHandler<BroadStringEvents<TEvents>>>;
 	"*"?: EventHandler<TEvents>;
 };
 
@@ -573,6 +579,12 @@ function getHandler<TEvents extends WebhookEvent>(
 	const specific = handlers[event.type as TEvents["type"]] as EventHandler<TEvents> | undefined;
 	if (specific) {
 		return specific;
+	}
+	if (!event.known) {
+		const unknownSpecific = handlers.unknown?.[event.type] as EventHandler<TEvents> | undefined;
+		if (unknownSpecific) {
+			return unknownSpecific;
+		}
 	}
 	if (catchAllHandlerScope === "unknown" && event.known) {
 		return undefined;

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -73,8 +73,19 @@ export type EventHandler<TEvent extends WebhookEvent = WebhookEvent> = (
 	context: HandlerContext<TEvent>,
 ) => unknown | Promise<unknown>;
 
+type LiteralEventType<TType extends string> = string extends TType ? never : TType;
+
+type LiteralEventTypes<TEvents extends WebhookEvent> =
+	TEvents extends WebhookEvent<infer TType> ? LiteralEventType<TType> : never;
+
+type EventHandlerTypeKeys<TEvents extends WebhookEvent> = [LiteralEventTypes<TEvents>] extends [
+	never,
+]
+	? TEvents["type"]
+	: LiteralEventTypes<TEvents>;
+
 export type EventHandlerMap<TEvents extends WebhookEvent> = {
-	[TType in TEvents["type"]]?: EventHandler<Extract<TEvents, { type: TType }>>;
+	[TType in EventHandlerTypeKeys<TEvents>]?: EventHandler<Extract<TEvents, { type: TType }>>;
 } & {
 	"*"?: EventHandler<TEvents>;
 };

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -73,11 +73,46 @@ describe("createWebhookEndpoint", () => {
 				"thing.updated": ({ event }) => {
 					expectTypeOf(event.payload).toEqualTypeOf<{ updatedId: string }>();
 				},
+				unknown: {
+					"thing.deleted": ({ event }) => {
+						expectTypeOf(event.payload).toEqualTypeOf<Record<string, unknown>>();
+					},
+				},
 				"*": ({ event }) => {
 					expectTypeOf(event).toEqualTypeOf<TestEventWithUnknown>();
 				},
 			},
 		});
+	});
+
+	it("prefers specific unknown event handlers over catch-all handlers", async () => {
+		const specificUnknown = vi.fn();
+		const catchAll = vi.fn();
+		const testProvider = provider({
+			extractEvent: () => ({
+				id: "evt_2",
+				type: "thing.deleted",
+				payload: { deletedId: "thing_2" },
+				envelope: {},
+				known: false,
+			}),
+		}) as unknown as ProviderDefinition<TestEventWithUnknown>;
+
+		const endpoint = createWebhookEndpoint<TestEventWithUnknown>({
+			provider: testProvider,
+			handlers: {
+				unknown: {
+					"thing.deleted": specificUnknown,
+				},
+				"*": catchAll,
+			},
+		});
+
+		const { result } = await endpoint.handleWithResult(request);
+
+		expect(result.status).toBe("handled");
+		expect(specificUnknown).toHaveBeenCalledOnce();
+		expect(catchAll).not.toHaveBeenCalled();
 	});
 
 	it("ignores verified events without a handler", async () => {

--- a/packages/core/test/core.test.ts
+++ b/packages/core/test/core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import {
 	createMemoryIdempotencyStore,
 	createMemoryReplayStore,
@@ -11,6 +11,11 @@ type TestEvent =
 	| (WebhookEvent<"thing.created", { id: string }> & { known: true })
 	| (WebhookEvent<"thing.updated", { id: string }> & { known: true })
 	| (WebhookEvent<"thing.unknown", { id: string }> & { known: false });
+
+type TestEventWithUnknown =
+	| (WebhookEvent<"thing.created", { createdId: string }> & { known: true })
+	| (WebhookEvent<"thing.updated", { updatedId: string }> & { known: true })
+	| (WebhookEvent<string, Record<string, unknown>> & { known: false });
 
 function provider(
 	overrides: Partial<ProviderDefinition<TestEvent>> = {},
@@ -54,6 +59,25 @@ describe("createWebhookEndpoint", () => {
 				delivery: expect.objectContaining({ method: "POST" }),
 			}),
 		);
+	});
+
+	it("narrows literal handlers when an event union includes an unknown string event", () => {
+		const testProvider = provider() as unknown as ProviderDefinition<TestEventWithUnknown>;
+
+		createWebhookEndpoint<TestEventWithUnknown>({
+			provider: testProvider,
+			handlers: {
+				"thing.created": ({ event }) => {
+					expectTypeOf(event.payload).toEqualTypeOf<{ createdId: string }>();
+				},
+				"thing.updated": ({ event }) => {
+					expectTypeOf(event.payload).toEqualTypeOf<{ updatedId: string }>();
+				},
+				"*": ({ event }) => {
+					expectTypeOf(event).toEqualTypeOf<TestEventWithUnknown>();
+				},
+			},
+		});
 	});
 
 	it("ignores verified events without a handler", async () => {

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -65,6 +65,8 @@ Unknown GitHub event names remain verified and catch-all handleable with `known:
 
 Runtime validation is envelope-only: the provider requires a non-empty `X-GitHub-Delivery`, a non-empty `X-GitHub-Event`, a JSON object body, optional string `action`, optional numeric `installation.id`, and optional numeric `repository.id`. GitHub payload objects stay permissive so GitHub can add fields without forcing package updates.
 
+Known event payload types are sourced from GitHub's generated OpenAPI webhook schemas via `@octokit/openapi-webhooks-types`. Event Handler payloads are compile-time typed by GitHub webhook event name and action-specific payload unions, while runtime validation remains limited to the Event Envelope.
+
 ## Idempotency And Replay Protection
 
 `X-GitHub-Delivery` becomes the core Webhook Event id and the provider replay key. With an Idempotency Store, a second processed delivery with the same GitHub Delivery ID is treated as a duplicate completed Webhook Event. With a Replay Store, the repeated delivery key is rejected as `replayed_delivery` before application handling.

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -42,7 +42,8 @@
 		"node": ">=18"
 	},
 	"dependencies": {
-		"@better-webhook/core": "workspace:*"
+		"@better-webhook/core": "workspace:*",
+		"@octokit/openapi-webhooks-types": "^12.1.0"
 	},
 	"devDependencies": {
 		"@better-webhook/biome-config": "workspace:*",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -43,7 +43,7 @@
 	},
 	"dependencies": {
 		"@better-webhook/core": "workspace:*",
-		"@octokit/openapi-webhooks-types": "^12.1.0"
+		"@octokit/openapi-webhooks-types": "12.1.0"
 	},
 	"devDependencies": {
 		"@better-webhook/biome-config": "workspace:*",

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -7,7 +7,7 @@ import type {
 } from "@better-webhook/core";
 import type { webhooks as GitHubWebhookDefinitions } from "@octokit/openapi-webhooks-types";
 
-export type GitHubPayload = object;
+export type GitHubPayload = Record<string, unknown>;
 
 type GitHubWebhookPayload<TName extends keyof GitHubWebhookDefinitions> =
 	GitHubWebhookDefinitions[TName]["post"]["requestBody"]["content"]["application/json"];
@@ -26,7 +26,7 @@ export type GitHubCheckRun = GitHubEventPayloads["check_run"]["check_run"];
 
 export type GitHubEventEnvelope<
 	TType extends string = string,
-	TPayload extends GitHubPayload = GitHubPayload,
+	TPayload extends object = GitHubPayload,
 > = {
 	id: string;
 	type: TType;

--- a/packages/github/src/github.ts
+++ b/packages/github/src/github.ts
@@ -5,51 +5,24 @@ import type {
 	WebhookDelivery,
 	WebhookEvent,
 } from "@better-webhook/core";
+import type { webhooks as GitHubWebhookDefinitions } from "@octokit/openapi-webhooks-types";
 
-export type GitHubPayload = Record<string, unknown>;
+export type GitHubPayload = object;
 
-export type GitHubUser = {
-	id?: number;
-	login?: string;
-	type?: string;
-	[key: string]: unknown;
-};
+type GitHubWebhookPayload<TName extends keyof GitHubWebhookDefinitions> =
+	GitHubWebhookDefinitions[TName]["post"]["requestBody"]["content"]["application/json"];
 
-export type GitHubRepository = {
-	id: number;
-	full_name?: string;
-	name?: string;
-	[key: string]: unknown;
-};
+export type GitHubUser = GitHubEventPayloads["ping"]["sender"];
 
-export type GitHubInstallation = {
-	id: number;
-	[key: string]: unknown;
-};
+export type GitHubRepository = GitHubEventPayloads["pull_request"]["repository"];
 
-export type GitHubPullRequest = {
-	id?: number;
-	number?: number;
-	title?: string;
-	state?: string;
-	user?: GitHubUser;
-	[key: string]: unknown;
-};
+export type GitHubInstallation = NonNullable<GitHubEventPayloads["installation"]["installation"]>;
 
-export type GitHubIssueComment = {
-	id?: number;
-	body?: string;
-	user?: GitHubUser;
-	[key: string]: unknown;
-};
+export type GitHubPullRequest = GitHubEventPayloads["pull_request"]["pull_request"];
 
-export type GitHubCheckRun = {
-	id?: number;
-	name?: string;
-	status?: string;
-	conclusion?: string | null;
-	[key: string]: unknown;
-};
+export type GitHubIssueComment = GitHubEventPayloads["issue_comment"]["comment"];
+
+export type GitHubCheckRun = GitHubEventPayloads["check_run"]["check_run"];
 
 export type GitHubEventEnvelope<
 	TType extends string = string,
@@ -75,43 +48,75 @@ export type GitHubEventEnvelope<
 };
 
 export type GitHubEventPayloads = {
-	ping: GitHubPayload & { zen?: string; hook_id?: number };
-	installation: GitHubPayload & {
-		action?: string;
-		installation?: GitHubInstallation;
-	};
-	installation_repositories: GitHubPayload & {
-		action?: string;
-		installation?: GitHubInstallation;
-	};
-	pull_request: GitHubPayload & {
-		action?: string;
-		number?: number;
-		pull_request?: GitHubPullRequest;
-		repository?: GitHubRepository;
-		installation?: GitHubInstallation;
-	};
-	issue_comment: GitHubPayload & {
-		action?: string;
-		comment?: GitHubIssueComment;
-		issue?: Record<string, unknown>;
-		repository?: GitHubRepository;
-		installation?: GitHubInstallation;
-	};
-	pull_request_review: GitHubPayload;
-	pull_request_review_comment: GitHubPayload;
-	pull_request_review_thread: GitHubPayload;
-	check_run: GitHubPayload & {
-		action?: string;
-		check_run?: GitHubCheckRun;
-		repository?: GitHubRepository;
-		installation?: GitHubInstallation;
-	};
-	check_suite: GitHubPayload;
-	status: GitHubPayload;
-	workflow_run: GitHubPayload;
-	workflow_job: GitHubPayload;
-	merge_group: GitHubPayload;
+	ping: GitHubWebhookPayload<"ping">;
+	installation:
+		| GitHubWebhookPayload<"installation-created">
+		| GitHubWebhookPayload<"installation-deleted">
+		| GitHubWebhookPayload<"installation-new-permissions-accepted">
+		| GitHubWebhookPayload<"installation-suspend">
+		| GitHubWebhookPayload<"installation-unsuspend">;
+	installation_repositories:
+		| GitHubWebhookPayload<"installation-repositories-added">
+		| GitHubWebhookPayload<"installation-repositories-removed">;
+	pull_request:
+		| GitHubWebhookPayload<"pull-request-assigned">
+		| GitHubWebhookPayload<"pull-request-auto-merge-disabled">
+		| GitHubWebhookPayload<"pull-request-auto-merge-enabled">
+		| GitHubWebhookPayload<"pull-request-closed">
+		| GitHubWebhookPayload<"pull-request-converted-to-draft">
+		| GitHubWebhookPayload<"pull-request-demilestoned">
+		| GitHubWebhookPayload<"pull-request-dequeued">
+		| GitHubWebhookPayload<"pull-request-edited">
+		| GitHubWebhookPayload<"pull-request-enqueued">
+		| GitHubWebhookPayload<"pull-request-labeled">
+		| GitHubWebhookPayload<"pull-request-locked">
+		| GitHubWebhookPayload<"pull-request-milestoned">
+		| GitHubWebhookPayload<"pull-request-opened">
+		| GitHubWebhookPayload<"pull-request-ready-for-review">
+		| GitHubWebhookPayload<"pull-request-reopened">
+		| GitHubWebhookPayload<"pull-request-review-request-removed">
+		| GitHubWebhookPayload<"pull-request-review-requested">
+		| GitHubWebhookPayload<"pull-request-synchronize">
+		| GitHubWebhookPayload<"pull-request-unassigned">
+		| GitHubWebhookPayload<"pull-request-unlabeled">
+		| GitHubWebhookPayload<"pull-request-unlocked">;
+	issue_comment:
+		| GitHubWebhookPayload<"issue-comment-created">
+		| GitHubWebhookPayload<"issue-comment-deleted">
+		| GitHubWebhookPayload<"issue-comment-edited">;
+	pull_request_review:
+		| GitHubWebhookPayload<"pull-request-review-dismissed">
+		| GitHubWebhookPayload<"pull-request-review-edited">
+		| GitHubWebhookPayload<"pull-request-review-submitted">;
+	pull_request_review_comment:
+		| GitHubWebhookPayload<"pull-request-review-comment-created">
+		| GitHubWebhookPayload<"pull-request-review-comment-deleted">
+		| GitHubWebhookPayload<"pull-request-review-comment-edited">;
+	pull_request_review_thread:
+		| GitHubWebhookPayload<"pull-request-review-thread-resolved">
+		| GitHubWebhookPayload<"pull-request-review-thread-unresolved">;
+	check_run:
+		| GitHubWebhookPayload<"check-run-completed">
+		| GitHubWebhookPayload<"check-run-created">
+		| GitHubWebhookPayload<"check-run-requested-action">
+		| GitHubWebhookPayload<"check-run-rerequested">;
+	check_suite:
+		| GitHubWebhookPayload<"check-suite-completed">
+		| GitHubWebhookPayload<"check-suite-requested">
+		| GitHubWebhookPayload<"check-suite-rerequested">;
+	status: GitHubWebhookPayload<"status">;
+	workflow_run:
+		| GitHubWebhookPayload<"workflow-run-completed">
+		| GitHubWebhookPayload<"workflow-run-in-progress">
+		| GitHubWebhookPayload<"workflow-run-requested">;
+	workflow_job:
+		| GitHubWebhookPayload<"workflow-job-completed">
+		| GitHubWebhookPayload<"workflow-job-in-progress">
+		| GitHubWebhookPayload<"workflow-job-queued">
+		| GitHubWebhookPayload<"workflow-job-waiting">;
+	merge_group:
+		| GitHubWebhookPayload<"merge-group-checks-requested">
+		| GitHubWebhookPayload<"merge-group-destroyed">;
 };
 
 export type KnownGitHubEventType = keyof GitHubEventPayloads;
@@ -134,8 +139,8 @@ export type KnownGitHubEvent = {
 
 export type UnknownGitHubEvent = WebhookEvent<
 	string,
-	GitHubPayload,
-	GitHubEventEnvelope<string, GitHubPayload>
+	Record<string, unknown>,
+	GitHubEventEnvelope<string, Record<string, unknown>>
 > & {
 	known: false;
 };

--- a/packages/github/test/github.test.ts
+++ b/packages/github/test/github.test.ts
@@ -6,7 +6,13 @@ import {
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { createGitHubSignatureHeader, parseGitHubSignatureHeader } from "../src/github.js";
 import {
+	type GitHubCheckRun,
 	type GitHubEventPayloads,
+	type GitHubIssueComment,
+	type GitHubPayload,
+	type GitHubPullRequest,
+	type GitHubRepository,
+	type GitHubUser,
 	type GitHubWebhookEvent,
 	github,
 	type KnownGitHubEventType,
@@ -325,6 +331,13 @@ describe("github provider", () => {
 				pull_request: ({ event }) => {
 					expectTypeOf(event.payload.pull_request.title).toEqualTypeOf<string>();
 				},
+				unknown: {
+					push: ({ event }) => {
+						const actionKey: string = "action";
+						expectTypeOf(event).toEqualTypeOf<UnknownGitHubEvent>();
+						expectTypeOf(event.payload[actionKey]).toEqualTypeOf<unknown>();
+					},
+				},
 				"*": ({ event }) => {
 					expectTypeOf(event).toEqualTypeOf<GitHubWebhookEvent>();
 				},
@@ -334,6 +347,17 @@ describe("github provider", () => {
 		expectTypeOf<Extract<GitHubWebhookEvent, UnknownGitHubEvent>["payload"]>().toEqualTypeOf<
 			Record<string, unknown>
 		>();
+		expectTypeOf<GitHubPayload>().toEqualTypeOf<Record<string, unknown>>();
+		expectTypeOf<GitHubPayload>().toHaveProperty("action").toEqualTypeOf<unknown>();
+		expectTypeOf<GitHubUser>().toHaveProperty("login").toEqualTypeOf<string>();
+		expectTypeOf<GitHubRepository>().toHaveProperty("id").toEqualTypeOf<number>();
+		expectTypeOf<GitHubPullRequest>().toHaveProperty("title").toEqualTypeOf<string>();
+		expectTypeOf<GitHubIssueComment>().toHaveProperty("body").toEqualTypeOf<string>();
+		expectTypeOf<GitHubCheckRun>()
+			.toHaveProperty("status")
+			.toEqualTypeOf<
+				"completed" | "in_progress" | "pending" | "queued" | "requested" | "waiting"
+			>();
 	});
 
 	it("uses generated GitHub webhook payload types for known events", () => {

--- a/packages/github/test/github.test.ts
+++ b/packages/github/test/github.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { createGitHubSignatureHeader, parseGitHubSignatureHeader } from "../src/github.js";
 import {
+	type GitHubEventPayloads,
 	type GitHubWebhookEvent,
 	github,
 	type KnownGitHubEventType,
@@ -322,7 +323,7 @@ describe("github provider", () => {
 			provider: github({ webhookSecret: secret }),
 			handlers: {
 				pull_request: ({ event }) => {
-					expectTypeOf(event.payload.pull_request?.title).toEqualTypeOf<string | undefined>();
+					expectTypeOf(event.payload.pull_request.title).toEqualTypeOf<string>();
 				},
 				"*": ({ event }) => {
 					expectTypeOf(event).toEqualTypeOf<GitHubWebhookEvent>();
@@ -333,5 +334,81 @@ describe("github provider", () => {
 		expectTypeOf<Extract<GitHubWebhookEvent, UnknownGitHubEvent>["payload"]>().toEqualTypeOf<
 			Record<string, unknown>
 		>();
+	});
+
+	it("uses generated GitHub webhook payload types for known events", () => {
+		createWebhookEndpoint({
+			provider: github({ webhookSecret: secret }),
+			handlers: {
+				ping: ({ event }) => {
+					expectTypeOf(event.payload.hook_id).toEqualTypeOf<number>();
+					expectTypeOf(event.payload.zen).toEqualTypeOf<string>();
+				},
+				installation: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<
+						"created" | "deleted" | "new_permissions_accepted" | "suspend" | "unsuspend"
+					>();
+					expectTypeOf(event.payload.installation.id).toEqualTypeOf<number>();
+				},
+				installation_repositories: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"added" | "removed">();
+					expectTypeOf(event.payload.repositories_added).toEqualTypeOf<
+						GitHubEventPayloads["installation_repositories"]["repositories_added"]
+					>();
+				},
+				issue_comment: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"created" | "deleted" | "edited">();
+					expectTypeOf(event.payload.comment.body).toEqualTypeOf<string>();
+				},
+				pull_request_review: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"dismissed" | "edited" | "submitted">();
+					expectTypeOf(event.payload.review.id).toEqualTypeOf<number>();
+				},
+				pull_request_review_comment: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"created" | "deleted" | "edited">();
+					expectTypeOf(event.payload.comment.path).toEqualTypeOf<string>();
+				},
+				pull_request_review_thread: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"resolved" | "unresolved">();
+					expectTypeOf(event.payload.thread.id).toEqualTypeOf<number>();
+				},
+				check_run: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<
+						"completed" | "created" | "requested_action" | "rerequested"
+					>();
+					expectTypeOf(event.payload.check_run.name).toEqualTypeOf<string>();
+				},
+				check_suite: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<
+						"completed" | "requested" | "rerequested"
+					>();
+					expectTypeOf(event.payload.check_suite.id).toEqualTypeOf<number>();
+				},
+				status: ({ event }) => {
+					expectTypeOf(event.payload.state).toEqualTypeOf<
+						"error" | "failure" | "pending" | "success"
+					>();
+					expectTypeOf(event.payload.sha).toEqualTypeOf<string>();
+				},
+				workflow_run: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<
+						"completed" | "in_progress" | "requested"
+					>();
+					expectTypeOf(event.payload.workflow_run.id).toEqualTypeOf<number>();
+				},
+				workflow_job: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<
+						"completed" | "in_progress" | "queued" | "waiting"
+					>();
+					expectTypeOf(event.payload.workflow_job.status).toEqualTypeOf<
+						"completed" | "in_progress" | "queued" | "waiting"
+					>();
+				},
+				merge_group: ({ event }) => {
+					expectTypeOf(event.payload.action).toEqualTypeOf<"checks_requested" | "destroyed">();
+					expectTypeOf(event.payload.merge_group.head_sha).toEqualTypeOf<string>();
+				},
+			},
+		});
 	});
 });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the GitHub webhook provider from hand-written payload types to generated OpenAPI schemas from `@octokit/openapi-webhooks-types`, and adds a new `unknown` handler map in `EventHandlerMap` to route unknown events by name before falling through to the `"*"` catch-all.

- **Generated payload types**: `GitHubEventPayloads` now maps each known event name to a union of action-specific octokit payloads; helper types (`GitHubUser`, `GitHubRepository`, etc.) are derived by indexing into those payloads rather than being hand-written.
- **`unknown` handler map**: `EventHandlerMap` gains an optional `unknown` record keyed by event-type string, only surfaced on provider unions that include a broad-string event member; `getHandler` checks this map before the `"*"` catch-all for events with `known === false`.
- **`GitHubEventEnvelope` constraint widened**: `TPayload` constraint changed from `extends Record<string, unknown>` to `extends object` to accommodate the richer generated types.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration to generated types is mechanical and well-tested; the new unknown handler map is additive and guarded by both runtime and compile-time checks.

All runtime behavior is preserved: handler lookup order is unchanged for known events, the new unknown map is only consulted when event.known===false, and the catch-all path is untouched. Breaking type changes are correctly declared as a major release in the changeset. The comprehensive type-level test suite covers all 14 known event types and the new unknown routing path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/github/src/github.ts | Core change: GitHubEventPayloads migrated to generated octokit types; helper exported types now derived by indexing into payload unions; GitHubEventEnvelope constraint widened from Record<string,unknown> to object. |
| packages/core/src/pipeline.ts | New type utilities split literal vs. broad-string event keys; EventHandlerMap gains unknown map; getHandler checks unknown map before "*" for events where known===false. |
| packages/core/test/core.test.ts | Adds tests for type narrowing with unknown-string event unions and runtime routing preference for specific unknown handlers over catch-all. |
| packages/github/test/github.test.ts | Extended type-level tests verify generated payload shapes for all known event types; adds unknown-map routing test for push events. |
| packages/github/package.json | Adds @octokit/openapi-webhooks-types 12.1.0 as a pinned production dependency. |
| .changeset/github-webhook-payload-types.md | Major bump for @better-webhook/github (breaking type changes), minor bump for @better-webhook/core (new EventHandlerMap feature). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Delivery] --> B[verify]
    B -->|ok| C[extractEvent]
    B -->|fail| Z[rejected]
    C --> D{event.known?}
    D -->|true| E["handlers[event.type]"]
    D -->|false| F["handlers[event.type]"]
    E -->|found| H[invoke handler]
    E -->|not found| G{catchAllScope?}
    F -->|found| H
    F -->|not found| F2["handlers.unknown[event.type]"]
    F2 -->|found| H
    F2 -->|not found| G
    G -->|scope=unknown AND known| I[ignored]
    G -->|otherwise| J["handlers.*"]
    J -->|found| H
    J -->|not found| I
    H --> K[handled]
```

<sub>Reviews (2): Last reviewed commit: ["feat(github)!: tighten generated payload..."](https://github.com/endalk200/better-webhook/commit/aa5ca8ffb2c4dcd76e7dab70e8d68b0e566006db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34722358)</sub>

<!-- /greptile_comment -->